### PR TITLE
Per-project configuration loader

### DIFF
--- a/src/N98/Magento/Command/ConfigurationLoader.php
+++ b/src/N98/Magento/Command/ConfigurationLoader.php
@@ -28,6 +28,9 @@ class ConfigurationLoader
         }
         if($cwd && file_exists($projectConfigFile)) {
             $projectConfig = Yaml::parse($projectConfigFile);
+            foreach($projectConfig['autoloaders'] as $key => &$value) {
+                $value = str_replace('%path%', $cwd, $value);
+            }
             $config = $this->mergeArrays($config, $projectConfig);
         }
 


### PR DESCRIPTION
It seems like it would be useful to allow n98-magerun to load configuration based on the project that you're currently operating on. This would allow commands to be added on a per-project basis (e.g. a product importer for a specific magento store, commands for extensions) and for defaults to be set per-project (installation settings etc).

This is just a proof of concept for now, I'm initiating this pull request mainly to discuss the idea and implementation.

The configuration is merged in this order (subsequent sources take precedence):
- Global (supplied by n98-magerun)
- Per user (~/.n98-magerun.yaml)
- Per project (.n98-magerun)

I've added in a clumsy `%path%` variable that can be used in per-project configurations to allow for autoloader paths that are relative to the project.
