### PR TITLE
Undefined property in CheckCommand.php

### DIFF
--- a/src/N98/Magento/Command/System/CheckCommand.php
+++ b/src/N98/Magento/Command/System/CheckCommand.php
@@ -15,6 +15,11 @@ class CheckCommand extends AbstractMagentoCommand
      */
     protected $infos;
 
+    /**
+     * @var int
+     */
+    protected $_verificationTimeOut = 30;
+
     protected function configure()
     {
         $this


### PR DESCRIPTION
Running `n98-magerun.phar sys:check` leads in the current version to following exception due to a missing property/class var:

```
[Exception]
Notice: Undefined property: N98\Magento\Command\System\CheckCommand::$_verificationTimeOut  in phar:///path/to/n98-magerun.phar/src/N98/Magento/Command/System/CheckCommand.php on line 163
```

This patch adds the property with a default cURL timeout of 30s. Please feel free to change that.
