### PR TITLE
Fire the adminhtml_cache_flush_all event before flushing the cache

### DIFF
--- a/src/N98/Magento/Command/Cache/FlushCommand.php
+++ b/src/N98/Magento/Command/Cache/FlushCommand.php
@@ -28,6 +28,7 @@ class FlushCommand extends AbstractCacheCommand
     {
         $this->detectMagento($output, true);
         if ($this->initMagento()) {
+            \Mage::dispatchEvent('adminhtml_cache_flush_all', array('output' => $output));
             \Mage::app()->getCacheInstance()->flush();
             $output->writeln('<info>Cache cleared</info>');
 


### PR DESCRIPTION
This event is fired by the Magento core immediately before flushing cache storage.  Firing it from n98-magerun as well allows anything listening to this event (e.g. a varnish cache clearer) to respond the same way when n98-magerun clears the cache as it would from the Magento admin panel.
