### PR TITLE
Add encrypt/decrypt support to config commands

### DIFF
--- a/src/N98/Magento/Command/Config/AbstractConfigCommand.php
+++ b/src/N98/Magento/Command/Config/AbstractConfigCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace N98\Magento\Command\Config;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+
+abstract class AbstractConfigCommand extends AbstractMagentoCommand
+{
+    /**
+     * @return \Mage_Core_Model_Abstract
+     */
+    protected function getEncryptionModel()
+    {
+        return $this->_getModel('core/encryption', $mage2ClassName = null)
+            ->setHelper($this->getCoreHelper());
+    }
+}

--- a/src/N98/Magento/Command/Config/DumpCommand.php
+++ b/src/N98/Magento/Command/Config/DumpCommand.php
@@ -2,13 +2,12 @@
 
 namespace N98\Magento\Command\Config;
 
-use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DumpCommand extends AbstractMagentoCommand
+class DumpCommand extends AbstractConfigCommand
 {
     protected function configure()
     {

--- a/src/N98/Magento/Command/Config/SetCommand.php
+++ b/src/N98/Magento/Command/Config/SetCommand.php
@@ -2,13 +2,12 @@
 
 namespace N98\Magento\Command\Config;
 
-use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SetCommand extends AbstractMagentoCommand
+class SetCommand extends AbstractConfigCommand
 {
     protected function configure()
     {
@@ -19,6 +18,7 @@ class SetCommand extends AbstractMagentoCommand
             ->addArgument('value', InputArgument::REQUIRED, 'The config value')
             ->addOption('scope', null, InputOption::VALUE_OPTIONAL, 'The config value\'s scope', 'default')
             ->addOption('scope-id', null, InputOption::VALUE_OPTIONAL, 'The config value\'s scope ID', '0')
+            ->addOption('encrypt', null, InputOption::VALUE_NONE, 'The config value should be encrypted using local.xml\'s crypt key')
         ;
     }
 
@@ -42,11 +42,25 @@ class SetCommand extends AbstractMagentoCommand
             $config = $this->_getConfigModel();
             $config->saveConfig(
                 $input->getArgument('path'),
-                $input->getArgument('value'),
+                $this->_formatValue($input->getArgument('value'), $input->getOption('encrypt')),
                 $input->getOption('scope'),
                 $input->getOption('scope-id')
             );
             $output->writeln('<comment>' . $input->getArgument('path') . "</comment> => <comment>" . $input->getArgument('value') . '</comment>');
         }
+    }
+
+    /**
+     * @param string $value
+     * @param boolean $encryptionRequired
+     * @return string
+     */
+    protected function _formatValue($value, $encryptionRequired)
+    {
+        if ($encryptionRequired) {
+            $value = $this->getEncryptionModel()->encrypt($value);
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
Config values can be decrypted and viewed by calling n98-magerun config:get
--decrypt key

Config values can be set encrypted by calling n98-magerun config:set --encrypt <key>
<unencrypted-value>
