### PR TITLE
Fix for cases where a module may be installed that doesn't have a config.xml

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Rewrite/AbstractRewriteCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/AbstractRewriteCommand.php
@@ -28,7 +28,12 @@ abstract class AbstractRewriteCommand extends AbstractMagentoCommand
             }
 
             // Load config of module
-            $xml = \simplexml_load_file(\Mage::getConfig()->getModuleDir('etc', $moduleName) . DIRECTORY_SEPARATOR . 'config.xml');
+            $configXmlFile = \Mage::getConfig()->getModuleDir('etc', $moduleName) . DIRECTORY_SEPARATOR . 'config.xml';
+            if (! file_exists($configXmlFile)) {
+                continue;
+            }
+
+            $xml = \simplexml_load_file($configXmlFile);
             if ($xml) {
                 $rewriteElements = $xml->xpath('//rewrite');
                 foreach ($rewriteElements as $element) {


### PR DESCRIPTION
I think I hit this once when there was a module
that was installed in app/etc/modules but didn't have any actual module
directory or config.xml.

Then again, perhaps it's best to simply disable any module that doesn't have a config.xml b/c it should be impossible that they'd be doing anything at all.
