### PR TITLE
Support for a custom home path to be specified in config.xml

### DIFF
--- a/src/N98/Magento/Command/ConfigurationLoader.php
+++ b/src/N98/Magento/Command/ConfigurationLoader.php
@@ -31,7 +31,8 @@ class ConfigurationLoader
         }
 
         // Check if there is a user config file. ~/.n98-magerun.yaml
-        $homeDirectory = getenv('HOME');
+        $helper = new \N98\Util\Environment();
+        $homeDirectory = $helper->getHomeDirectory();
         $personalConfigFile = $homeDirectory . DIRECTORY_SEPARATOR . '.' . $this->_customConfigFilename;
         if ($homeDirectory && file_exists($personalConfigFile)) {
             $personalConfig = Yaml::parse($personalConfigFile);

--- a/src/N98/Util/Environment.php
+++ b/src/N98/Util/Environment.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace N98\Util;
+
+use Symfony\Component\Yaml\Yaml;
+
+class Environment
+{
+    public function getHomeDirectory()
+    {
+        $configPath = __DIR__ . '/../../../config.yaml';
+        $config = Yaml::parse($configPath);
+        if (isset($config['environment']['home'])) {
+            return $config['environment']['home'];
+        }
+
+        if (getenv('HOME')) {
+            return getenv('HOME');
+        }
+
+        throw new \Exception("Wasn't able to determine the home directory.  This may be because the script is being executed by a different user than you're expecting. Try setting the home directory in config.yaml ($configPath)");
+    }
+}


### PR DESCRIPTION
I ran into issues when trying to run magerun from within a
shell_exec() context in a PHP app, so I needed to specify the
path to the home directory explicitly.  Perhaps there's a more
elegant solution to this though.
