### PR TITLE
Added dev:log:size command

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -31,6 +31,7 @@ use N98\Magento\Command\Design\DemoNoticeCommand as DesignDemoNoticeCommand;
 use N98\Magento\Command\Developer\ConsoleCommand as DevelopmentConsoleCommand;
 use N98\Magento\Command\Developer\LogCommand as DevelopmentLogCommand;
 use N98\Magento\Command\Developer\LogDbCommand as DevelopmentLogDbCommand;
+use N98\Magento\Command\Developer\LogSizeCommand as DevelopmentLogSizeCommand;
 use N98\Magento\Command\Developer\Module\CreateCommand as ModuleCreateCommand;
 use N98\Magento\Command\Developer\Module\ListCommand as ModuleListCommand;
 use N98\Magento\Command\Developer\Module\Observer\ListCommand as ModuleObserverListCommand;
@@ -198,6 +199,7 @@ class Application extends BaseApplication
         $this->add(new SymlinksCommand());
         $this->add(new DevelopmentLogCommand());
         $this->add(new DevelopmentLogDbCommand());
+        $this->add(new DevelopmentLogSizeCommand());
         $this->add(new ModuleListCommand());
         $this->add(new ModuleRewriteListCommand());
         $this->add(new ModuleRewriteConflictsCommand());

--- a/src/N98/Magento/Command/Developer/LogSizeCommand.php
+++ b/src/N98/Magento/Command/Developer/LogSizeCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace N98\Magento\Command\Developer;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LogSizeCommand extends AbstractMagentoCommand
+{
+    protected $_input = null;
+    protected $_output = null;
+    
+    protected function configure()
+    {
+        $this->setName('dev:log:size')
+             ->addArgument('log_filename', InputArgument::REQUIRED, 'Name of log file.')
+             ->setDescription('Get size of log file');
+    }
+    
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->_input = $input;
+        $this->_output = $output;
+
+        $this->detectMagento($output);
+        $this->initMagento();
+        
+        $dir = \Mage::getBaseDir('log');
+        $fileName = $input->getArgument('log_filename');
+        $path = $dir . DS . $fileName;
+        
+        if (file_exists($path)) {
+            $size = @filesize($path);
+            
+            if ($size === false) {
+                throw new \RuntimeException('Couldn\t detect filesize.');
+            }
+        } else {
+            $size = 0;
+        }
+        
+        $output->writeln("$size");
+    }
+}


### PR DESCRIPTION
The new command returns the filesize of a specified log file (in bytes). This can be useful for monitoring tools and the like.

Wasn't sure which steps from the [release process](https://github.com/netz98/n98-magerun/wiki/Release-process) should be carried out by me. Therefore I only added the new functionality.
