### PR TITLE
Added dev:report:count command

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -37,6 +37,7 @@ use N98\Magento\Command\Developer\Module\Observer\ListCommand as ModuleObserverL
 use N98\Magento\Command\Developer\Module\Rewrite\ConflictsCommand as ModuleRewriteConflictsCommand;
 use N98\Magento\Command\Developer\Module\Rewrite\ListCommand as ModuleRewriteListCommand;
 use N98\Magento\Command\Developer\ProfilerCommand;
+use N98\Magento\Command\Developer\ReportCountCommand as DevelopmentReportCountCommand;
 use N98\Magento\Command\Developer\SymlinksCommand;
 use N98\Magento\Command\Developer\TemplateHintsBlocksCommand;
 use N98\Magento\Command\Developer\TemplateHintsCommand;
@@ -198,6 +199,7 @@ class Application extends BaseApplication
         $this->add(new SymlinksCommand());
         $this->add(new DevelopmentLogCommand());
         $this->add(new DevelopmentLogDbCommand());
+        $this->add(new DevelopmentReportCountCommand());
         $this->add(new ModuleListCommand());
         $this->add(new ModuleRewriteListCommand());
         $this->add(new ModuleRewriteConflictsCommand());

--- a/src/N98/Magento/Command/Developer/ReportCountCommand.php
+++ b/src/N98/Magento/Command/Developer/ReportCountCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace N98\Magento\Command\Developer;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReportCountCommand extends AbstractMagentoCommand
+{
+    protected $_input = null;
+    protected $_output = null;
+    
+    protected function configure()
+    {
+        $this->setName('dev:report:count')
+             ->setDescription('Get count of report files');
+    }
+    
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->_input = $input;
+        $this->_output = $output;
+
+        $this->detectMagento($output);
+        $this->initMagento();
+        
+        $dir = \Mage::getBaseDir('var') . DS . 'report' . DS;
+        $count = $this->getFileCount($dir);
+        
+        $output->writeln("$count");
+    }
+    
+    /**
+     * Returns the number of files in the directory.
+     * 
+     * @param string $path Path to the directory
+     * @return int
+     */
+    protected function getFileCount($path)
+    {
+        $result = 0;
+        
+        if (file_exists($path) && is_dir($path)) {
+            foreach (new \DirectoryIterator($path) as $entry) {
+                if ($entry->isFile()) {
+                    $result++;
+                }
+            }    
+        }
+        
+        return $result;
+    }
+}


### PR DESCRIPTION
The new command returns the count of files in the var/report directory. This can be useful for monitoring tools and the like.

Wasn't sure which steps from the [release process](https://github.com/netz98/n98-magerun/wiki/Release-process) should be carried out by me. Therefore I only added the new functionality.
