### PR TITLE
Added gzip compression option to db:dump and db:import command

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -186,11 +186,14 @@ Dump database
 
 Dumps configured magento database with `mysqldump`.
 
+* Requires MySQL CLI tools
+
 Arguments:
     filename        Dump filename
 
 Options:
      --add-time               Adds time to filename (only if filename was not provided)
+     --compression (-c)       Compress the dump file using one of the supported algorithms
      --only-command           Print only mysqldump command. Do not execute
      --print-only-filename    Execute and prints not output except the dump filename
      --no-single-transaction  Do not use single-transaction (not recommended, this is blocking)
@@ -213,7 +216,13 @@ Or directly to stdout:
 .. code-block:: sh
 
    $ n98-magerun.phar db:dump --stdout
+   
+Use compression (gzip cli tool has to be installed):   
 
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump --compression="gzip" 
+   
 Stripped Database Dump
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -249,9 +258,26 @@ Imports an SQL file with mysql cli client into current configured database.
 
 * Requires MySQL CLI tools
 
+Arguments:
+    filename        Dump filename
+
+Options:
+     --compression (-c)       The compression of the specified file
+     --only-command           Print only mysql command. Do not execute
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:dump
+
 .. code-block:: sh
 
    $ n98-magerun.phar db:import [--only-command] [filename]
+   
+Use decompression (gzip cli tool has to be installed):   
+
+.. code-block:: sh
+
+   $ n98-magerun.phar db:import --compression="gzip" [filename]    
 
 Database Console / MySQL Client
 """""""""""""""""""""""""""""""

--- a/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
+++ b/src/N98/Magento/Command/Database/AbstractDatabaseCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\Database;
 
 use N98\Magento\Command\AbstractMagentoCommand;
+use N98\Magento\Command\Database\Compressor;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -47,6 +48,40 @@ abstract class AbstractDatabaseCommand extends AbstractMagentoCommand
         }
     }
 
+    /**
+     * Generate help for compression
+     *
+     * @return string
+     * @throws \Exception
+     */
+    protected function getCompressionHelp()
+    {
+        $messages = array();
+        $messages[] = '';
+        $messages[] = '<comment>Compression option</comment>';
+        $messages[] = ' Supported compression: gzip';
+        $messages[] = ' The gzip cli tool has to be installed.';
+        return implode("\n", $messages);
+    }
+
+    /**
+     * @param string $type
+     * @return \N98\Magento\Command\Database\Compressor\AbstractCompressor
+     */
+    protected function getCompressor($type)
+    {
+        if ($type === null) {
+            return new Compressor\Uncompressed;
+        }
+        
+        switch ($type) {
+            case 'gzip':
+                return new Compressor\Gzip;
+            default:
+                throw new \InvalidArgumentException("Compression type '$type' is not supported.");
+        }
+    }
+    
     /**
      * @return string
      */

--- a/src/N98/Magento/Command/Database/Compressor/AbstractCompressor.php
+++ b/src/N98/Magento/Command/Database/Compressor/AbstractCompressor.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+abstract class AbstractCompressor
+{
+    /**
+     * Returns the command line for compressing the dump file.
+     * 
+     * @param string $command
+     * @return string
+     */
+    abstract public function getCompressingCommand($command);
+    
+    /**
+     * Returns the command line for decompressing the dump file.
+     * 
+     * @param string $mysqlCmd MySQL client tool connection string
+     * @param string $fileName Filename (shell argument escaped)
+     * @return string
+     */
+    abstract public function getDecompressingCommand($mysqlCmd, $fileName);
+    
+    /**
+     * Returns the file name for the compressed dump file.
+     * 
+     * @param string $fileName
+     * @return string
+     */
+    abstract public function getFileName($fileName);
+}

--- a/src/N98/Magento/Command/Database/Compressor/Gzip.php
+++ b/src/N98/Magento/Command/Database/Compressor/Gzip.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+class Gzip extends AbstractCompressor
+{
+    /**
+     * Returns the command line for compressing the dump file.
+     * 
+     * @param string $command
+     * @return string
+     */
+    public function getCompressingCommand($command)
+    {
+        return $command . ' | gzip -c ';
+    }
+    
+    /**
+     * Returns the command line for decompressing the dump file.
+     * 
+     * @param string $mysqlCmd MySQL client tool connection string
+     * @param string $fileName Filename (shell argument escaped)
+     * @return string
+     */
+    public function getDecompressingCommand($mysqlCmd, $fileName)
+    {
+        return 'gzip -dc < ' . $fileName . ' | ' . $mysqlCmd;
+    }
+    
+    /**
+     * Returns the file name for the compressed dump file.
+     * 
+     * @param string $fileName
+     * @return string
+     */
+    public function getFileName($fileName)
+    {
+        if (substr($fileName, -3, 3) === '.gz') {
+            return $fileName;
+        } elseif (substr($fileName, -4, 4) === '.sql') {
+            $fileName .= '.gz';
+        } else {
+            $fileName .= '.sql.gz';
+        }
+        
+        return $fileName;
+    }
+}

--- a/src/N98/Magento/Command/Database/Compressor/Uncompressed.php
+++ b/src/N98/Magento/Command/Database/Compressor/Uncompressed.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace N98\Magento\Command\Database\Compressor;
+
+class Uncompressed extends AbstractCompressor
+{
+    /**
+     * Returns the command line for compressing the dump file.
+     * 
+     * @param string $command
+     * @return string
+     */
+    public function getCompressingCommand($command)
+    {
+        return $command;
+    }
+    
+    /**
+     * Returns the command line for decompressing the dump file.
+     * 
+     * @param string $mysqlCmd MySQL client tool connection string
+     * @param string $fileName Filename (shell argument escaped)
+     * @return string
+     */
+    public function getDecompressingCommand($mysqlCmd, $fileName)
+    {
+        return $mysqlCmd . ' < ' . $fileName;
+    }
+    
+    /**
+     * Returns the file name for the compressed dump file.
+     * 
+     * @param string $fileName
+     * @return string
+     */
+    public function getFileName($fileName)
+    {
+        if (substr($fileName, -4, 4) !== '.sql') {
+            $fileName .= '.sql';
+        }
+        
+        return $fileName;
+    }
+}


### PR DESCRIPTION
Added feature as requested in #72.

It is possible to create and import gzipped dump files by specifying --compression="gzip" or -c gzip.

**To be discussed / done**
- I tested some variations (including/excluding table stripping, adding timestamp and so on) and it worked. Still I'd like somebody to verify everything works.
- Speaking about tests: I didn't implement unit tests. Yes, I admit it.
- The class for gzip is hardcoded in \N98\Magento\Command\Database\AbstractDatabaseCommand::getCompressor(). Do you have an opinion how to better handle this (configuration?)?

**If you want to implement more compressors**
- Add your own compression type (e.g. tar) to \N98\Magento\Command\Database\AbstractDatabaseCommand::getCompressor()
- Create your class in namespace N98\Magento\Command\Database\Compressor extending AbstractCompressor (see gzip implementation).
