### PR TITLE
Performance improvements for customer:create:dummy

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11,12 +11,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "d498e73363f8dae5b9984bf84ff2a2ca27240925"
+                "reference": "c93aecee4d3998d17a1986f042187d38dd394397"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/d498e73363f8dae5b9984bf84ff2a2ca27240925",
-                "reference": "d498e73363f8dae5b9984bf84ff2a2ca27240925",
+                "url": "https://api.github.com/repos/composer/composer/zipball/c93aecee4d3998d17a1986f042187d38dd394397",
+                "reference": "c93aecee4d3998d17a1986f042187d38dd394397",
                 "shasum": ""
             },
             "require": {
@@ -72,7 +72,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2013-06-13 15:45:05"
+            "time": "2013-06-20 12:05:54"
         },
         {
             "name": "fzaninotto/faker",
@@ -129,7 +129,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/justinrainbow/json-schema/archive/v1.1.0.zip",
+                "url": "https://github.com/justinrainbow/json-schema/zipball/v1.1.0",
                 "reference": "v1.1.0",
                 "shasum": ""
             },
@@ -142,7 +142,6 @@
                     "JsonSchema": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "NewBSD"
             ],
@@ -406,17 +405,17 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.3.0",
+            "version": "v2.3.1",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "v2.3.0-RC1"
+                "reference": "v2.3.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/v2.3.0-RC1",
-                "reference": "v2.3.0-RC1",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/v2.3.1",
+                "reference": "v2.3.1",
                 "shasum": ""
             },
             "require": {

--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -50,13 +50,17 @@ HELP;
     {
         $this->detectMagento($output, true);
         if ($this->initMagento()) {
+            
+            $res = $this->getCustomerModel()->getResource();
+            
+            $faker = \Faker\Factory::create($input->getArgument('locale'));
+            $faker->addProvider(new \N98\Util\Faker\Provider\Internet($faker));
 
             $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);
 
+            $res->beginTransaction();
             for ($i = 0; $i < $input->getArgument('count'); $i++) {
                 $customer = $this->getCustomerModel();
-
-                $faker = \Faker\Factory::create($input->getArgument('locale'));
 
                 $email = $faker->safeEmail;
 
@@ -78,7 +82,12 @@ HELP;
                 } else {
                     $output->writeln('<error>Customer ' . $email . ' already exists</error>');
                 }
+                if ($i % 1000 == 0) {
+                    $res->commit();
+                    $res->beginTransaction();
+                }
             }
+            $res->commit();
 
         }
     }

--- a/src/N98/Util/Faker/Provider/Internet.php
+++ b/src/N98/Util/Faker/Provider/Internet.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace N98\Util\Faker\Provider;
+
+class Internet extends \Faker\Provider\Internet {
+
+    // Reduce the chance of conflicts.
+    protected static $userNameFormats = array(
+        '{{lastName}}.{{firstName}}.######',
+        '{{firstName}}.{{lastName}}.######',
+        '{{firstName}}.######',
+        '?{{lastName}}.######',
+    );
+    
+}


### PR DESCRIPTION
Made some changes to the customer:create:dummy command to make it work better when trying to create large (100,000s) amounts of dummy customers.
- Uses transactions to commit blocks of 1000 customers at a time, instead of per customer.
- Modified name formats to add more random digits to email addresses to avoid collisions.
