### PR TITLE
Fixes db:dump ignoring --no-interaction flag

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -290,7 +290,7 @@ class DumpCommand extends AbstractDatabaseCommand
             $dialog = $this->getHelperSet()->get('dialog');
             $defaultName = $namePrefix . $this->dbSettings['dbname'] . $nameSuffix
                          . $nameExtension;
-            if (!$input->getOption('force')) {
+            if (!$input->getOption('force') && !$input->getOption('no-interaction')) {
                 $fileName = $dialog->ask($output, '<question>Filename for SQL dump:</question> [<comment>' . $defaultName . '</comment>]', $defaultName);
             } else {
                 $fileName = $defaultName;


### PR DESCRIPTION
When `db:dump` is run with the `--no-interaction` flag the user is still prompted for the SQL dumps filename, this fixes that and lets it default the same as if they used the `--force` flag.
