### PR TITLE
Use correct setup class to create product attributes

### DIFF
--- a/src/N98/Magento/Command/Developer/Setup/Script/Attribute/EntityType/CatalogProduct.php
+++ b/src/N98/Magento/Command/Developer/Setup/Script/Attribute/EntityType/CatalogProduct.php
@@ -88,7 +88,7 @@ TEXT;
 //generate script using simple string concatenation, making
         //a single tear fall down the cheek of a CS professor
         $script = "<?php
-\$setup = new Mage_Eav_Model_Entity_Setup('core_setup');
+\$setup = new Mage_Catalog_Model_Resource_Setup('core_setup');
 
 \$attr = $arrayCode;
 \$setup->addAttribute('catalog_product', '" . $this->attribute->getAttributeCode() . "', \$attr);


### PR DESCRIPTION
When creating product attributes, use Mage_Catalog_Model_Resource_Setup so that the additional product specific fields (e.g. is_configurable) are populated.

Addresses the issue https://github.com/netz98/n98-magerun/issues/194
