### PR TITLE
Feature: Detect Magento in sub-folder (i.e. public, web-root, ..)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,13 @@ script:
   folders:
     - /usr/local/share/n98-magerun/scripts
 
+detect:
+  subFolders:
+    - web
+    - public
+    - webroot
+    - web-root
+
 commands:
   customCommands:
     - N98\Magento\Command\Admin\DisableNotificationsCommand

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -115,6 +115,22 @@ class Application extends BaseApplication
     }
 
     /**
+     * Get names of sub-folders to be scanned during Magento detection
+     * @return array
+     */
+    public function getDetectSubFolders()
+    {
+        $tempConfig = $this->config = $this->_loadConfig(array());
+
+        if (isset($tempConfig['detect'])) {
+            if (isset($tempConfig['detect']['subFolders'])) {
+                return $tempConfig['detect']['subFolders'];
+            }
+        }
+        return array();
+    }
+
+    /**
      * Search for magento root folder
      */
     public function detectMagento()
@@ -132,7 +148,8 @@ class Application extends BaseApplication
 
         $this->getHelperSet()->set(new MagentoHelper(), 'magento');
         $magentoHelper = $this->getHelperSet()->get('magento'); /* @var $magentoHelper MagentoHelper */
-        $magentoHelper->detect($folder);
+        $subFolders = $this->getDetectSubFolders();
+        $magentoHelper->detect($folder,$subFolders);
         $this->_magentoRootFolder = $magentoHelper->getRootFolder();
         $this->_magentoEnterprise = $magentoHelper->isEnterpriseEdition();
         $this->_magentoMajorVersion = $magentoHelper->getMajorVersion();

--- a/src/N98/Magento/Command/ConfigurationLoader.php
+++ b/src/N98/Magento/Command/ConfigurationLoader.php
@@ -19,16 +19,23 @@ class ConfigurationLoader
     protected $_customConfigFilename = 'n98-magerun.yaml';
 
     /**
+     * Load config
+     * If $magentoRootFolder is null, only non-project config is loaded
+     *
      * @param array $config
      * @param string $magentoRootFolder
      */
     public function __construct($config, $magentoRootFolder)
     {
         $config = $this->loadDistConfig($config);
-        $config = $this->loadPluginConfig($config, $magentoRootFolder);
+        if ($magentoRootFolder != null) {
+            $config = $this->loadPluginConfig($config, $magentoRootFolder);
+        }
         $config = $this->loadSystemConfig($config);
         $config = $this->loadUserConfig($config);
-        $config = $this->loadProjectConfig($magentoRootFolder, $config);
+        if ($magentoRootFolder != null) {
+            $config = $this->loadProjectConfig($magentoRootFolder, $config);
+        }
         $config = $this->initAutoloaders($magentoRootFolder, $config);
 
         $this->_configArray = $config;

--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -38,13 +38,18 @@ class MagentoHelper extends AbstractHelper
      * Start Magento detection
      *
      * @param string $folder
+     * @param array $subFolders Sub-folders to check
      */
-    public function detect($folder)
+    public function detect($folder, $subFolders = array())
     {
         $folders = $this->splitPathFolders($folder);
         $folders = $this->checkModman($folders);
+        $folders = array_merge($folders, $subFolders);
 
         foreach (array_reverse($folders) as $searchFolder) {
+            if (!is_dir($searchFolder)) {
+                continue;
+            }
             if ($this->_search($searchFolder)) {
                break;
             }


### PR DESCRIPTION
See also #73

Detect Magento in sub-folders like public, web-root (configurable)

To have this still configurable, I temporarily load the config (igoring those config locations which depend on the Magento folder)
