### PR TITLE
LogicException thrown by script:repo:list where no script directories exist

### DIFF
--- a/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
+++ b/src/N98/Magento/Command/Script/Repository/ScriptLoader.php
@@ -35,8 +35,10 @@ class ScriptLoader
                 unset($this->_scriptFolders[$key]);
             }
         }
-
-        $this->findScripts();
+        
+        if (count($this->_scriptFolders)) {
+            $this->findScripts();
+        }
     }
 
     protected function findScripts()


### PR DESCRIPTION
Where neither `~/.n98-magerun/scripts` or `/usr/local/share/n98-magerun/scripts` exist on the local file-system, running scripts:repo:list will throw an exception:

```
[LogicException]                                                               
You must call one of in() or append() methods before iterating over a Finder.
```

Creating either one (or both) of the final scripts directories will solve the issue and output the expected "no script file found" message.
