### PR TITLE
[Bug fix] Dont instantiate classes when checking inheritance

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
@@ -141,9 +141,7 @@ class ConflictsCommand extends AbstractRewriteCommand
                 if (class_exists($classes[$i])
                     && class_exists($classes[$i + 1])
                 ) {
-                    $firstClass = new $classes[$i];
-                    $nextClass = new $classes[$i + 1];
-                    if (! ($firstClass instanceof $nextClass)) {
+                    if (! is_a($classes[$i], $classes[$i + 1], true)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Issue was introduced in fix for bug 185 that causes classes to be instantiated in check conflicts command: https://github.com/netz98/n98-magerun/issues/185
