### PR TITLE
Fix for https://github.com/netz98/n98-magerun/issues/202

### DIFF
--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -115,6 +115,9 @@ class MagentoHelper extends AbstractHelper
     protected function checkModman($folders)
     {
         foreach (array_reverse($folders) as $searchFolder) {
+            if(!is_readable($current)) {
+                continue;
+            }            
             $finder = Finder::create();
             $finder
                 ->files()


### PR DESCRIPTION
I'm not really sure, if the bug is in the Finder component itself or not, maybe the ignoreUnreadableDirs does only apply to iterated directories and not to the ones you supply to construct the finder itself (it would make sense)?
