### PR TITLE
Fix for https://github.com/netz98/n98-magerun/issues/202

### DIFF
--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -115,6 +115,9 @@ class MagentoHelper extends AbstractHelper
     protected function checkModman($folders)
     {
         foreach (array_reverse($folders) as $searchFolder) {
+            if(!is_readable($searchFolder)) {
+                continue;
+            }            
             $finder = Finder::create();
             $finder
                 ->files()


### PR DESCRIPTION
Somehow the ignoreUnreadableDirs-flag for the Finder-component doesn't really ignore unreadable directory.
