### PR TITLE
Fix magento root directory detection false positive

### DIFF
--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -151,20 +151,20 @@ class MagentoHelper extends AbstractHelper
     {
         $finder = Finder::create();
         $finder
-            ->directories()
             ->ignoreUnreadableDirs(true)
             ->depth(0)
             ->followLinks()
             ->name('app')
             ->name('skin')
             ->name('lib')
+            ->name('index.php')
             ->in($searchFolder);
 
-        if ($finder->count() >= 2) {
+        if ($finder->count() >= 3) {
             $files = iterator_to_array($finder, false);
             /* @var $file \SplFileInfo */
 
-            if (count($files) == 2) {
+            if (count($files) == 3) {
                 // Magento 2 has no skin folder.
                 // @TODO find a better magento 2.x check
                 $this->_magentoMajorVersion = \N98\Magento\Application::MAGENTO_MAJOR_VERSION_2;


### PR DESCRIPTION
Search for index.php in addition to app/, skin/ and lib/ - this
should prevent MageRun from identifying module directories as
the Magento root by mistake

Fixes #229
