### PR TITLE
fix flush to use Enterprise_PageCache_Model_Cache only for 1.11 and up, ...

### DIFF
--- a/src/N98/Magento/Command/Cache/FlushCommand.php
+++ b/src/N98/Magento/Command/Cache/FlushCommand.php
@@ -39,7 +39,7 @@ class FlushCommand extends AbstractCacheCommand
             $output->writeln('<info>Cache cleared</info>');
 
             /* Since Magento 1.10 we have an own cache handler for FPC */
-            if ($this->_magentoEnterprise && version_compare(\Mage::getVersion(), '1.10.0.0', '>=')) {
+            if ($this->_magentoEnterprise && version_compare(\Mage::getVersion(), '1.11.0.0', '>=')) {
                 \Enterprise_PageCache_Model_Cache::getCacheInstance()->flush();
                 $output->writeln('<info>FPC cleared</info>');
             }


### PR DESCRIPTION
...rather than 1.10.  Fixes "Fatal error: Class 'Enterprise_PageCache_Model_Cache' not found in phar:///usr/local/bin/mr/src/N98/Magento/Command/Cache/FlushCommand.php on line 43" when running n98-magerun cache:flush on 1.10.0.1.  The Cache model wasn't added until 1.11
