### PR TITLE
fix db:dump --single-transaction switch

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -190,8 +190,8 @@ HELP;
         }
 
         $dumpOptions = '';
-        if ($input->getOption('no-single-transaction')) {
-            $dumpOptions = '--single-transaction ';
+        if (!$input->getOption('no-single-transaction')) {
+            $dumpOptions = '--single-transaction --quick ';
         }
 
         if ($input->getOption('human-readable')) {


### PR DESCRIPTION
The readme says `db:dump` has an option:

> `--no-single-transaction`
> Do not use single-transaction (not recommended, this is blocking)

https://github.com/netz98/n98-magerun/blob/develop/src/N98/Magento/Command/Database/DumpCommand.php#L193
Current behaviour is the inverse of this, if `--no-single-transaction` is specified the mysqldump actually gets the argument `--single-transaction`

`--single-transaction` actually blocks and only applies to InnoDB tables: http://dev.mysql.com/doc/refman/5.1/en/mysqldump.html#option_mysqldump_single-transaction

I added the `--quick` argument as it's recommended for large tables when using `--single-transaction`

To be clear this now puts `--single-transaction --quick` in the default `$dumpOptions`. This matches my interpretation of what it says in the README and help command.
I am happy to refactor this (including help and README) to make this command opt-in if that was your intent.  
