### PR TITLE
Added @search to @development database dump table group.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -254,7 +254,7 @@ commands:
 
       - id: development
         description: Removes logs and trade data so developers do not have to work with real customer data
-        tables: @trade @stripped
+        tables: @trade @stripped @search
 
       - id: ee_changelog
         description: Changelog tables of new indexer since EE 1.13


### PR DESCRIPTION
@search was recently added I think by default it should be included in @development table group for database dumps.
