### PR TITLE
[TASK] Allow directory as argument for db:dump

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -319,10 +319,11 @@ HELP;
             }
         }
 
-        if (($fileName = $input->getArgument('filename')) === null && !$input->getOption('stdout')) {
+        if ((($fileName = $input->getArgument('filename')) === null || ($isDir = is_dir($fileName))) && !$input->getOption('stdout')) {
             /** @var DialogHelper $dialog */
             $dialog      = $this->getHelperSet()->get('dialog');
             $defaultName = $namePrefix . $this->dbSettings['dbname'] . $nameSuffix . $nameExtension;
+            if (isset($isDir) && $isDir) $defaultName = rtrim($fileName, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $defaultName;
             if (!$input->getOption('force')) {
                 $fileName = $dialog->ask($output, '<question>Filename for SQL dump:</question> [<comment>'
                     . $defaultName . '</comment>]', $defaultName


### PR DESCRIPTION
Added an is_dir check to support the following syntax:

```
rick@rick-desktop:~/public_html/magento/web$ ./n98-magerun.phar db:dump ../


  Dump MySQL Database  


Filename for SQL dump: [../2013-12-14_210711_magento.sql]
Start dumping database magento to file ../2013-12-14_210711_magento.sql
Finished
```
