### PR TITLE
Updated documentation to include a few undocumented parameters to config:get

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -479,11 +479,11 @@ Arguments:
     path        The config path
 
 Options:
-    --scope          The config value's scope (default, websites, stores)
-    --scope-id       The config value's scope ID
-    --Decrypt        Decrypt the config value using local.xml's crypt key
-    --update-script  Output as update script lines
-    --magerun-script Output for usage with config:set
+    --scope             The config value's scope (default, websites, stores)
+    --scope-id          The config value's scope ID
+    --decrypt           Decrypt the config value using local.xml's crypt key
+    --update-script     Output as update script lines
+    --magerun-script    Output for usage with config:set
 
 Help:
     If path is not set, all available config items will be listed. path may contain wildcards (*) 


### PR DESCRIPTION
I noticed that "update-script" and "--magerun-script" parameters of config:get where missing in the documentation. I also added a small example of wildcard usage. Please advise.
