### PR TITLE
Add force use database option for when installing with --noDownload

### DIFF
--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -66,6 +66,7 @@ class InstallCommand extends AbstractMagentoCommand
                 'If set skips download step. Used when installationFolder is already a Magento installation that has ' .
                 'to be installed on the given database.'
             )
+            ->addOption('forceUseDb', null, InputOption::VALUE_OPTIONAL, 'If --noDownload passed, force to use given database if it already exists.')
             ->setDescription('Install magento')
         ;
 
@@ -401,7 +402,7 @@ HELP;
                 return $db;
             }
 
-            if ($input->getOption('noDownload')) {
+            if ($input->getOption('noDownload') && !$input->getOption('forceUseDb')) {
                 $output->writeln("<error>Database {$this->config['db_name']} already exists.</error>");
 
                 return false;


### PR DESCRIPTION
This is an example of how to solve #288. There may be a better solution but I think this won't break BC. It feels a bit hacky though
