### PR TITLE
loadXML must be called AFTER preserveWhiteSpace

### DIFF
--- a/src/N98/Magento/Command/Config/DumpCommand.php
+++ b/src/N98/Magento/Command/Config/DumpCommand.php
@@ -54,9 +54,9 @@ HELP;
                 throw new \InvalidArgumentException('xpath was not found');
             }
             $dom = new \DOMDocument();
-            $dom->loadXML($config->asXml());
             $dom->preserveWhiteSpace = false;
             $dom->formatOutput = true;
+            $dom->loadXML($config->asXml());
             $output->writeln($dom->saveXML());
         }
     }


### PR DESCRIPTION
I created a very simple test case and could confirm this for PHP 5.3.10-1ubuntu3.9. If I load the XML **_before**_ calling `$dom->preserveWhiteSpace = false;` the passed XML will remain unchanged. If I load the XML **_after**_ setting the value everything works as expected. This might be related to issue #3.
