### PR TITLE
Implement bash completion in bash

### DIFF
--- a/autocompletion/bash/bash_complete
+++ b/autocompletion/bash/bash_complete
@@ -24,10 +24,11 @@ _n98-magerun()
     while read command help; do
         # skip section headers
         if [[ $command =~ ":" ]]; then
-                POSSIBLE+=($command)
+                POSSIBLE+=("$command")
         fi
     done <<< "$help"
 
+    possible=${POSSIBLE[@]}
     COMPREPLY=( $(compgen -W "${possible}" -- ${cur}) )
     return 0
 }


### PR DESCRIPTION
This PR reimplements bash completion in bash. This prevents a second forking of PHP just to parse the options. This is marginally faster :)

Issue: netz98/n98-magerun#294

I would like to implement bash completion for more than just top-level `magerun`. This could be implemented by looking for the first entry in `COMP_WORDS` that is not an `--option` and putting that in $subcommand. Then we could run ``magerun help $subcommand` and parse the sub options.

If we want to implement filename completion for e.g. `magerun db:import`, we need to have code support for certain commands, because parsing `magerun help` does not help us here.

But this is not for this PR.
