### PR TITLE
Add bash completion for common magerun aliases

### DIFF
--- a/autocompletion/bash/bash_complete
+++ b/autocompletion/bash/bash_complete
@@ -32,4 +32,6 @@ echo implode("\n", $comps);
 }
 
 complete -F _n98-magerun n98-magerun.phar
+complete -F _n98-magerun n98-magerun
+complete -F _n98-magerun magerun
 COMP_WORDBREAKS=${COMP_WORDBREAKS//:}


### PR DESCRIPTION
Please add bash completion for these two common magerun aliases. This way, if you provide symlinks in `/usr/local/bin/` for customer convenience, bash completion actually works :)

There are no other tools that I know of that are named magerun, so there is no chance of name collision.
