### PR TITLE
added Magento CE install option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -139,6 +139,14 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
+      - name: magento-ce-1.9.0.0
+        version: 1.9.0.0
+        dist:
+          url: http://www.magentocommerce.com/downloads/assets/1.9.0.0/magento-1.9.0.0.tar.gz
+          type: tar
+        extra:
+          sample-data: sample-data-1.9.0.0
+          
       - name: magento-ce-1.8.1.0
         version: 1.8.1.0
         dist:
@@ -222,6 +230,11 @@ commands:
           reference: master
 
     demo-data-packages:
+      - name: sample-data-1.9.0.0
+        version: 1.9.0.0
+        dist:
+          url: http://www.magentocommerce.com/downloads/assets/1.9.0.0/magento-sample-data-1.9.0.0.tar.gz
+          type: tar
       - name: sample-data-1.6.1.0
         version: 1.6.1.0
         dist:


### PR DESCRIPTION
Added links to both installation as sample data for Magento 1.9.0.0
Magento CE 1.9 uses different sample data from the other versions in the preceding list
http://www.magentocommerce.com/knowledge-base/entry/installing-sample-data-archive-for-magento-ce
