### PR TITLE
Keep dataflow profiles when stripping temp tables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -283,7 +283,7 @@ commands:
 
       - id: dataflowtemp
         description: Temporary tables of the dataflow import/export tool
-        tables: dataflow_*
+        tables: dataflow_batch dataflow_batch_export dataflow_batch_import dataflow_import_data dataflow_session
 
       - id: stripped
         description: Standard definition for a stripped dump (logs and dataflow)


### PR DESCRIPTION
Using db:dump with --strip=@dataflowtemp will strip all tables that
start with dataflow_*. The dataflow_profile tables are not temporary
tables and should be retained.
