### PR TITLE
search in working directory for modules inside a vendor directory

### DIFF
--- a/src/N98/Magento/Command/ConfigurationLoader.php
+++ b/src/N98/Magento/Command/ConfigurationLoader.php
@@ -217,6 +217,25 @@ class ConfigurationLoader
                 }
             }
 
+            /**
+             * Allow modules to be placed in vendor folder of current execution context
+             */
+            if (is_dir('vendor')) {
+                $finder = Finder::create();
+                $finder
+                    ->files()
+                    ->depth(2)
+                    ->followLinks()
+                    ->ignoreUnreadableDirs(true)
+                    ->name('n98-magerun.yaml')
+                    ->in('vendor');
+
+                foreach ($finder as $file) { /* @var $file \Symfony\Component\Finder\SplFileInfo */
+                    $this->registerPluginConfigFile($magentoRootFolder, $file);
+                }
+                
+            }
+
             if (count($moduleBaseFolders) > 0) {
                 // Glob plugin folders
                 $finder = Finder::create();


### PR DESCRIPTION
I have a module which delivers a magerun command.
I want to be able to use it without deploying it into the magento library directory.

This patch makes it possible.

As this is my first submission to the project, is there any extra work needed to get this merged?
