### PR TITLE
print root warning to std_error

### DIFF
--- a/src/N98/Magento/EventSubscriber.php
+++ b/src/N98/Magento/EventSubscriber.php
@@ -32,7 +32,7 @@ class EventSubscriber implements EventSubscriberInterface
      */
     public function checkRunningAsRootUser(ConsoleEvent $event)
     {
-        $output = $event->getOutput();
+        $output = $event->getOutput()->getErrorOutput();
         if (OperatingSystem::isLinux() || OperatingSystem::isMacOs()) {
             if (function_exists('posix_getuid')) {
                 if (posix_getuid() === 0) {


### PR DESCRIPTION
We have been getting corrupt gzips when running `n98-magerun  db:dump --compression=gzip --stdout > /tmp/db.sql.gz` as root. We have tracked it down to the `checkRunningAsRootUser` error message. We have changed the method to output to std_error. The gzips now work. 
