### PR TITLE
Unlink sym-linked folders instead of recursively removing

### DIFF
--- a/src/N98/Magento/Command/Developer/Log/SizeCommand.php
+++ b/src/N98/Magento/Command/Developer/Log/SizeCommand.php
@@ -47,7 +47,7 @@ class SizeCommand extends AbstractLogCommand
             }
 
             if ($input->getOption('human')) {
-                $output->writeln(\N98\Util\Filesystem::humandFilesize($size));
+                $output->writeln(\N98\Util\Filesystem::humanFileSize($size));
             } else {
                 $output->writeln("$size");
             }

--- a/src/N98/Util/Filesystem.php
+++ b/src/N98/Util/Filesystem.php
@@ -62,7 +62,10 @@ class Filesystem
                     $path = $directory . '/' . $item;
 
                     // if the new path is a directory
-                    if (is_dir($path)) {
+                    // don't recursively delete symlinks - just remove the actual link
+                    // this is helpful for extensions sym-linked from vendor directory
+                    // previous behaviour would wipe out the files in the vendor directory
+                    if (!is_link($path) && is_dir($path)) {
                         // we call this function with the new path
                         $this->recursiveRemoveDirectory($path);
 
@@ -79,10 +82,7 @@ class Filesystem
             // if the option to empty is not set to true
             if ($empty == false) {
                 // try to delete the now empty directory
-                if (!rmdir($directory)) {
-                    // return false if not possible
-                    return false;
-                }
+                return rmdir($directory);
             }
             // return success
             return true;
@@ -97,11 +97,10 @@ class Filesystem
      *
      * @return string
      */
-    public static function humandFilesize($bytes, $decimals = 2)
+    public static function humanFileSize($bytes, $decimals = 2)
     {
-        $sz = 'BKMGTP';
+        $units = array('B', 'K', 'M', 'G', 'T', 'P');
         $factor = floor((strlen($bytes) - 1) / 3);
-
-        return sprintf("%.{$decimals}f", $bytes / pow(1024, $factor)) . @$sz[$factor];
+        return sprintf("%.{$decimals}f%s", $bytes / pow(1024, $factor), $units[$factor]);
     }
 }

--- a/tests/N98/Util/FilesystemTest.php
+++ b/tests/N98/Util/FilesystemTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace N98\Util;
+
+use N98\Util\Filesystem;
+
+/**
+ * Class FilesystemTest
+ * @package N98\Util
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class FilesystemTest extends \PHPUnit_Framework_TestCase
+{
+    protected $fileSystem;
+
+    public function setUp()
+    {
+        $this->fileSystem = new Filesystem();
+    }
+
+    public function testRecursiveCopy()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        $folder1    = $basePath . "/folder1";
+        $folder2    = $basePath . "/folder2";
+        $file1      = $folder1 . "/file1.txt";
+        $file2      = $folder2 . "/file2.txt";
+        $dest       = sys_get_temp_dir() . "/n98_copy_dest";
+
+        @mkdir($folder1, 0777, true);
+        @mkdir($folder2, 0777, true);
+        touch($file1);
+        touch($file2);
+
+        $this->fileSystem->recursiveCopy($basePath, $dest);
+        $this->assertFileExists($dest . "/folder1/file1.txt");
+        $this->assertFileExists($dest . "/folder2/file2.txt");
+
+        //cleanup
+        unlink($file1);
+        unlink($file2);
+        rmdir($folder1);
+        rmdir($folder2);
+        rmdir($basePath);
+
+        unlink($dest . "/folder1/file1.txt");
+        unlink($dest . "/folder2/file2.txt");
+        rmdir($dest . "/folder1");
+        rmdir($dest . "/folder2");
+        rmdir($dest);
+    }
+
+    public function testRecursiveCopyWithBlacklist()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        $folder1    = $basePath . "/folder1";
+        $folder2    = $basePath . "/folder2";
+        $file1      = $folder1 . "/file1.txt";
+        $ignoreMe   = $folder1 . "/ignore.me";
+        $file2      = $folder2 . "/file2.txt";
+        $dest       = sys_get_temp_dir() . "/n98_copy_dest";
+
+        @mkdir($folder1, 0777, true);
+        @mkdir($folder2, 0777, true);
+        touch($file1);
+        touch($file2);
+
+        $this->fileSystem->recursiveCopy($basePath, $dest, array('ignore.me'));
+        $this->assertFileExists($dest . "/folder1/file1.txt");
+        $this->assertFileExists($dest . "/folder2/file2.txt");
+        $this->assertFileNotExists($dest . "/folder1/ignore.me");
+
+        //cleanup
+        unlink($file1);
+        unlink($file2);
+        rmdir($folder1);
+        rmdir($folder2);
+        rmdir($basePath);
+
+        unlink($dest . "/folder1/file1.txt");
+        unlink($dest . "/folder2/file2.txt");
+        rmdir($dest . "/folder1");
+        rmdir($dest . "/folder2");
+        rmdir($dest);
+    }
+
+    public function testRecursiveDirectoryRemoveUnLinksSymLinks()
+    {
+        $tmp            = sys_get_temp_dir();
+        $basePath       = $tmp . "/n98_testdir";
+        $symLinked      = $tmp . "/n98_linked";
+        $symLinkedFile = $symLinked . "/symlinkme.txt";
+
+        @mkdir($basePath, 0777, true);
+        @mkdir($symLinked, 0777, true);
+
+        touch($symLinkedFile);
+
+        $result = @symlink($symLinked, $basePath . "/symlink");
+        $this->assertTrue($result);
+
+        $this->fileSystem->recursiveRemoveDirectory($basePath);
+
+        $this->assertFileExists($symLinkedFile);
+        $this->assertFileNotExists($basePath);
+    }
+
+    public function testRecursiveRemove()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        $folder1    = $basePath . "/folder1";
+        $folder2    = $basePath . "/folder2";
+        $file1      = $folder1 . "/file1.txt";
+        $file2      = $folder2 . "/file2.txt";
+
+        @mkdir($folder1, 0777, true);
+        @mkdir($folder2, 0777, true);
+        touch($file1);
+        touch($file2);
+
+        $this->fileSystem->recursiveRemoveDirectory($basePath);
+        $this->assertFileNotExists($basePath);
+    }
+
+    public function testRecursiveRemoveWithTrailingSlash()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        $folder1    = $basePath . "/folder1";
+        $folder2    = $basePath . "/folder2";
+        $file1      = $folder1 . "/file1.txt";
+        $file2      = $folder2 . "/file2.txt";
+
+        @mkdir($folder1, 0777, true);
+        @mkdir($folder2, 0777, true);
+        touch($file1);
+        touch($file2);
+
+        $this->fileSystem->recursiveRemoveDirectory($basePath . "/");
+        $this->assertFileNotExists($basePath);
+    }
+
+    public function testFalseIsReturnedIfDirectoryNotExist()
+    {
+        $this->assertFalse($this->fileSystem->recursiveRemoveDirectory("not-a-folder"));
+    }
+
+    public function testFalseIsReturnedIfDirectoryNotReadable()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        @mkdir($basePath, 0000, true);
+
+        $this->assertFalse($this->fileSystem->recursiveRemoveDirectory($basePath));
+        //cleanup
+        rmdir($basePath);
+    }
+
+    public function testParentIsNotRemovedIfEmptyIsTrue()
+    {
+        $tmp        = sys_get_temp_dir();
+        $basePath   = $tmp . "/n98_testdir";
+        $folder1    = $basePath . "/folder1";
+        $folder2    = $basePath . "/folder2";
+        $file1      = $folder1 . "/file1.txt";
+        $file2      = $folder2 . "/file2.txt";
+
+        @mkdir($folder1, 0777, true);
+        @mkdir($folder2, 0777, true);
+        touch($file1);
+        touch($file2);
+
+        $this->fileSystem->recursiveRemoveDirectory($basePath, true);
+        $this->assertFileExists($basePath);
+        $this->assertFileNotExists($folder1);
+        $this->assertFileNotExists($folder2);
+    }
+
+    /**
+     * @param int $bytes
+     * @param int $decimalPlaces
+     * @param string $expected
+     * @dataProvider convertedBytesProvider
+     */
+    public function testConvertBytesToHumanReadable($bytes, $decimalPlaces, $expected)
+    {
+        $res = Filesystem::humanFileSize($bytes, $decimalPlaces);
+        $this->assertSame($expected, $res);
+
+    }
+
+    /**
+     * @return array
+     */
+    public static function convertedBytesProvider()
+    {
+        return array(
+            array(20000000,     2,  '19.07M'),
+            array(20000000,     3,  '19.073M'),
+            array(2000000000,   2,  '1.86G'),
+            array(2,            2,  '2.00B'),
+            array(2048,         2,  '2.00K'),
+        );
+    }
+}


### PR DESCRIPTION
This PR does a couple of things:
- Instead of recursively removing sym-linked directories, it now just removes the symlink. This is helpful for modules installed via [magento-comoser-installer](https://github.com/magento-hackathon/magento-composer-installer) when using the sym-link deploy method, previous behavior wiped out the files in vendor directory.
- Cover Filesystem with unit-tests
- Fix humanFileSize method name
