### PR TITLE
Fix attribute removal for other entity types

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1010,6 +1010,12 @@ Remove an attribute:
 
    $ n98-magerun.phar eav:attribute:remove entityType attributeCode
 
+You can also remove multiple attributes in one go if they are of the same type
+
+.. code-block:: sh
+
+   $ n98-magerun.phar eav:attribute:remove entityType attributeCode1 attributeCode2 ... attributeCode10
+
 
 Development IDE Support
 """""""""""""""""""""""


### PR DESCRIPTION
The validation on this command was wrong, I was doing to much validation on the entity type code, so I couldn't remove attributes on `order` , `customer` entity type etc.

Also looks like there is maybe a bug in Magento:

The code: 
`\Mage::getModel('eav/config')->getAttribute('order', 'someAttribute');`

Results in the following:

```
Fatal error: Call to undefined method Mage_Sales_Model_Resource_Order::getDefaultAttributes() in /var/www/magento/htdocs/app/code/core/Mage/Eav/Model/Config.php on line 429
```

That method is called in [here](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Eav/Model/Config.php#L429)

Anyway - I fixed it by using `getEntityAttributeCodes` and checking for existence in array instead.

I enhanced the tests to create and remove an attribute for each entity type. 
