### PR TITLE
Fixed missing sprintf when creating Exception in sys:cron:run command

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -65,7 +65,7 @@ HELP;
                     throw new \Exception('Invalid model/method definition, expecting "model/class::method".');
                 }
                 if (!($model = \Mage::getModel($run[1])) || !method_exists($model, $run[2])) {
-                    throw new \Exception('Invalid callback: %s::%s does not exist', $run[1], $run[2]);
+                    throw new \Exception(sprintf('Invalid callback: %s::%s does not exist', $run[1], $run[2]));
                 }
                 $callback = array($model, $run[2]);
 


### PR DESCRIPTION
sprintf was missing, so the two parameters for sprintf where given to the constructor of the Exception class instead resulting in the following error:
Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in phar:///usr/local/bin/n98-magerun.phar/src/N98/Magento/Command/System/Cron/RunCommand.php on line 68