### PR TITLE
[TASK] Add index event tables to @ids table group of the db:dump command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -362,8 +362,8 @@ commands:
         tables: "catalogsearch_*"
 
       - id: idx
-        description: Tables with _idx suffix
-        tables: "*_idx"
+        description: Tables with _idx suffix and index event tables
+        tables: "*_idx index_event index_process_event"
 
   N98\Magento\Command\Customer\ListCommand:
     limit: 1000

--- a/readme.rst
+++ b/readme.rst
@@ -317,6 +317,7 @@ Available Table Groups:
 * @trade Current trade data (customers and orders). You usally do not want those in developer systems.
 * @search Search related tables (catalogsearch_)
 * @development Removes logs, sessions and trade data so developers do not have to work with real customer data
+* @idx Tables with _idx suffix and index event tables
 
 Extended: https://github.com/netz98/n98-magerun/wiki/Stripped-Database-Dumps
 


### PR DESCRIPTION
The index_event and index_process_event tables are needed to record the status
of dependent indexers (currently only the cataloginventory index), but are never
cleared. Excluding these tables from a database dump can significantly reduce
the size of the dump.