### PR TITLE
[TASK] Add importexporttemp table group for db:dump command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -325,13 +325,17 @@ commands:
         description: Temporary tables of the dataflow import/export tool
         tables: dataflow_batch dataflow_batch_export dataflow_batch_import dataflow_import_data dataflow_session
 
+      - id: importexporttemp
+        description: Temporary tables of the Import/Export module
+        tables: importexport_importdata
+
       - id: sessions
         description: Database session tables
         tables: core_session
 
       - id: stripped
         description: Standard definition for a stripped dump (logs, sessions and dataflow)
-        tables: @log @dataflowtemp @sessions
+        tables: @log @dataflowtemp @importexporttemp @sessions
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)

--- a/readme.rst
+++ b/readme.rst
@@ -311,7 +311,8 @@ Available Table Groups:
 
 * @log Log tables
 * @dataflowtemp Temporary tables of the dataflow import/export tool
-* @stripped Standard definition for a stripped dump (logs, sessions and dataflow)
+* @importexporttemp Temporary tables of the Import/Export module
+* @stripped Standard definition for a stripped dump (logs, sessions, dataflow and importexport)
 * @sales Sales data (orders, invoices, creditmemos etc)
 * @customers Customer data
 * @trade Current trade data (customers and orders). You usally do not want those in developer systems.

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -62,7 +62,8 @@ Available Table Groups:
 
 * @log Log tables
 * @dataflowtemp Temporary tables of the dataflow import/export tool
-* @stripped Standard definition for a stripped dump (logs and dataflow)
+* @importexporttemp Temporary tables of the Import/Export module
+* @stripped Standard definition for a stripped dump (logs, dataflow and importexport)
 * @sales Sales data (orders, invoices, creditmemos etc)
 * @customers Customer data
 * @trade Current trade data (customers and orders). You usally do not want those in developer systems.


### PR DESCRIPTION
The @importexporttemp group is added to the @stripped group such that it not only removes the temp tables for the Dataflow module, but also for ImportExport.
The @iimportexporttemp group only contains one table (importexport_importdata, which can contain both product and customer data), but has been added such that it is analogous to the handling of the dataflow temp tables.