### PR TITLE
[BUGFIX] Improve sys:cron:run input handling

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -14,10 +14,12 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         $table = array();
 
         foreach (\Mage::getConfig()->getNode('crontab/jobs')->children() as $job) {
-            $table[(string) $job->getName()] = array('Job'  => (string) $job->getName()) + $this->getSchedule($job);
+            $table[] = array('Job'  => (string) $job->getName()) + $this->getSchedule($job);
         }
 
-        ksort($table);
+        usort($table, function($a, $b) {
+            return strcmp($a['Job'], $b['Job']);
+        });
 
         return $table;
     }

--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -111,9 +111,8 @@ HELP;
      */
     protected function askJobCode(InputInterface $input, OutputInterface $output, $jobs)
     {
-        $i = 1;
-        foreach ($jobs as $job) {
-            $question[] = '<comment>[' . ($i++) . ']</comment> ' . $job['Job'] . PHP_EOL;
+        foreach ($jobs as $key => $job) {
+            $question[] = '<comment>[' . ($key+1) . ']</comment> ' . $job['Job'] . PHP_EOL;
         }
         $question[] = '<question>Please select job: </question>' . PHP_EOL;
 
@@ -121,17 +120,13 @@ HELP;
             $output,
             $question,
             function ($typeInput) use ($jobs) {
-                $subArray = array_slice($jobs, $typeInput - 1, 1);
-                $firstElement = current($subArray);
-                if (!$firstElement) {
-                    throw new InvalidArgumentException('Invalid job');
+                if (!isset($jobs[$typeInput - 1])) {
+                    throw new \InvalidArgumentException('Invalid job');
                 }
-
-                return $firstElement['Job'];
+                return $jobs[$typeInput - 1]['Job'];
             }
         );
 
         return $jobCode;
     }
-
 }


### PR DESCRIPTION
When sys:cron:run is called without any arguments, a dialog is presented to the user where he can choose a job by entering a number.
It was however also possible to execute a job by entering invalid input:
- if 0 is entered, the last job in the list was executed
- if a negative number was entered, the first job in the list was executed
- if non-numeric value was entered, the last job in the list was executed

This commit fixes the above issues by showing an error if incorrect input is supplied.