### PR TITLE
Use return code of 1 if rewrite conflicts are found

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
@@ -68,8 +68,10 @@ HELP;
                         array_map(array($table, 'appendRow'), $tableData);
                         $output->write($table->render());
                         $output->writeln('<error>' . $conflictCounter . ' conflict' . ($conflictCounter > 1 ? 's' : '') . ' was found!</error>');
+                        return 1;
                     } else {
                         $output->writeln('<info>No rewrite conflicts were found.</info>');
+                        return 0;
                     }
                 }
             }


### PR DESCRIPTION
I have found it useful in scripting to have this command return an error exit code if a conflict is found