### PR TITLE
move composer from require to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
         "symfony/validator": "2.6.*",
         "n98/junit-xml": "1.0.*",
         "fzaninotto/faker": "1.4.*",
-        "composer/composer": "1.0.*@dev",
         "twig/twig": "1.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",
+        "composer/composer": "1.0.*@dev",
         "mikey179/vfsStream": "1.4.*"
     },
     "autoload": {


### PR DESCRIPTION
Since composer is installed anyway, you only need it for development and not on the actual system, magerun is installed to.

Since @dev does only work in the root composer.json, Installation of magerun will fail if you have a minimum-stability above alpha.

Moving it to require-dev solves this, since composer still is required in your dev environment, but not anymore if you require magerun in a project