### PR TITLE
Some small database connection & db:info improvements

### DIFF
--- a/src/N98/Magento/Command/Database/InfoCommand.php
+++ b/src/N98/Magento/Command/Database/InfoCommand.php
@@ -57,8 +57,9 @@ HELP;
             );
         } else {
             $pdoConnectionString = sprintf(
-                'mysql:host=%s;dbname=%s',
+                'mysql:host=%s;port=%s;dbname=%s',
                 $this->dbSettings['host'],
+                isset($this->dbSettings['port']) ? $this->dbSettings['port'] : 3306,
                 $this->dbSettings['dbname']
             );
         }
@@ -70,8 +71,9 @@ HELP;
             $jdbcConnectionString = 'Connecting using JDBC through a unix socket isn\'t supported!';
         } else {
             $jdbcConnectionString = sprintf(
-                'jdbc:mysql://%s/%s?username=%s&password=%s',
+                'jdbc:mysql://%s:%s/%s?username=%s&password=%s',
                 $this->dbSettings['host'],
+                isset($this->dbSettings['port']) ? $this->dbSettings['port'] : 3306,
                 $this->dbSettings['dbname'],
                 $this->dbSettings['username'],
                 $this->dbSettings['password']

--- a/src/N98/Magento/Command/Database/InfoCommand.php
+++ b/src/N98/Magento/Command/Database/InfoCommand.php
@@ -48,20 +48,35 @@ HELP;
             $settings[$key] = (string) $value;
         }
 
-        $pdoConnectionString = sprintf(
-            'mysql:host=%s;dbname=%s',
-            $this->dbSettings['host'],
-            $this->dbSettings['dbname']
-        );
+        $pdoConnectionString = '';
+        if ($this->isSocketConnect) {
+            $pdoConnectionString = sprintf(
+                'mysql:unix_socket=%s;dbname=%s',
+                $this->dbSettings['unix_socket'],
+                $this->dbSettings['dbname']
+            );
+        } else {
+            $pdoConnectionString = sprintf(
+                'mysql:host=%s;dbname=%s',
+                $this->dbSettings['host'],
+                $this->dbSettings['dbname']
+            );
+        }
         $settings['PDO-Connection-String'] = $pdoConnectionString;
 
-        $jdbcConnectionString = sprintf(
-            'jdbc:mysql://%s/%s?username=%s&password=%s',
-            $this->dbSettings['host'],
-            $this->dbSettings['dbname'],
-            $this->dbSettings['username'],
-            $this->dbSettings['password']
-        );
+        $jdbcConnectionString = '';
+        if ($this->isSocketConnect) {
+            // isn't supported according to this post: http://stackoverflow.com/a/18493673/145829
+            $jdbcConnectionString = 'Connecting using JDBC through a unix socket isn\'t supported!';
+        } else {
+            $jdbcConnectionString = sprintf(
+                'jdbc:mysql://%s/%s?username=%s&password=%s',
+                $this->dbSettings['host'],
+                $this->dbSettings['dbname'],
+                $this->dbSettings['username'],
+                $this->dbSettings['password']
+            );
+        }
         $settings['JDBC-Connection-String'] = $jdbcConnectionString;
 
         $mysqlCliString = 'mysql ' . $this->getHelper('database')->getMysqlClientToolConnectionString();

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -113,10 +113,6 @@ class DatabaseHelper extends AbstractHelper
             throw new \Exception('pdo_mysql extension is not installed');
         }
 
-        if (!$this->isSocketConnect && strpos($this->dbSettings['host'], ':') !== false) {
-            list($this->dbSettings['host'], $this->dbSettings['port']) = explode(':', $this->dbSettings['host']);
-        }
-
         $this->_connection = new \PDO(
             $this->dsn(),
             $this->dbSettings['username'],

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -68,7 +68,7 @@ class DatabaseHelper extends AbstractHelper
             $this->dbSettings           = (array)$config->global->resources->default_setup->connection;
             $this->dbSettings['prefix'] = (string)$config->global->resources->db->table_prefix;
 
-            if (strpos($this->dbSettings['host'], ':') !== false) {
+            if (isset($this->dbSettings['host']) && strpos($this->dbSettings['host'], ':') !== false) {
                 list($this->dbSettings['host'], $this->dbSettings['port']) = explode(':', $this->dbSettings['host']);
             }
 
@@ -81,7 +81,7 @@ class DatabaseHelper extends AbstractHelper
             }
 
             // @see Varien_Db_Adapter_Pdo_Mysql->_connect()
-            if ( strpos($this->dbSettings['host'], '/') !== false ) {
+            if (isset($this->dbSettings['host']) && strpos($this->dbSettings['host'], '/') !== false ) {
                 $this->isSocketConnect = true;
                 $this->dbSettings['unix_socket'] = $this->dbSettings['host'];
                 unset($this->dbSettings['host']);
@@ -113,10 +113,7 @@ class DatabaseHelper extends AbstractHelper
             throw new \Exception('pdo_mysql extension is not installed');
         }
 
-        if (strpos($this->dbSettings['host'], '/') !== false) {
-            $this->dbSettings['unix_socket'] = $this->dbSettings['host'];
-            unset($this->dbSettings['host']);
-        } else if (strpos($this->dbSettings['host'], ':') !== false) {
+        if (!$this->isSocketConnect && strpos($this->dbSettings['host'], ':') !== false) {
             list($this->dbSettings['host'], $this->dbSettings['port']) = explode(':', $this->dbSettings['host']);
         }
 


### PR DESCRIPTION
Hi

I was testing Magento with a db connection using sockets and noticed a couple of PHP notices like this:
`Notice: Undefined index: host`

This pull request fixes this.

While fixing this, I noticed the output of the connection strings of the `db:info` command was incorrect when using sockets, this is fixed. I also noticed the connection strings didn't contain the port when not using sockets, so this is fixed too now.

I also removed some code from `DatabaseHelper::getConnection` which was already called in `DatabaseHelper::detectDbSettings` so that wasn't necessary anymore.

I do have some extra remarks about this pull request:
- I have no experience with the JDBC connection string, so the changes are based on info I found on the web
- I hardcoded port 3306, as I see it is also hardcoded in the `InstallCommand` class, but maybe it would be a good idea to define it somewhere in a `const`?