### PR TITLE
Update ordering of compare-versions so that output is alphabetised

### DIFF
--- a/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
+++ b/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
@@ -87,7 +87,13 @@ HELP;
             if (!$input->getOption('format')) {
 
                 usort($table, function($a, $b) {
-                    return $a['Status'] !== 'OK';
+                    if ($a['Status'] !== 'OK' && $b['Status'] === 'OK') {
+                        return 1;
+                    }
+                    if ($a['Status'] === 'OK' && $b['Status'] !== 'OK') {
+                        return -1;
+                    }
+                    return strcmp($a['Setup'], $b['Setup']);
                 });
 
                 array_walk($table, function (&$row) {


### PR DESCRIPTION
Updates the ordering of `sys:setup:compare-versions` so that it is output in alphabetical order.

Checked with the unit tests, and here's a sample of my run locally.
```
/lukerodgers.co.uk/checkouts/n98-magerun/bin/n98-magerun sys:setup:compare-versions
+-------------------------------+------------+------------+------------+--------+
| Setup                         | Module     | DB         | Data       | Status |
+-------------------------------+------------+------------+------------+--------+
| admin_setup                   | 1.6.1.1    | 1.6.1.1    | 1.6.1.1    | OK     |
| adminnotification_setup       | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| api2_setup                    | 1.0.0.0    | 1.0.0.0    | 1.0.0.0    | OK     |
| api_setup                     | 1.6.0.1    | 1.6.0.1    | 1.6.0.1    | OK     |
| backup_setup                  | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| bundle_setup                  | 1.6.0.0.1  | 1.6.0.0.1  | 1.6.0.0.1  | OK     |
| captcha_setup                 | 1.7.0.0.0  | 1.7.0.0.0  | 1.7.0.0.0  | OK     |
| catalog_setup                 | 1.6.0.0.19 | 1.6.0.0.19 | 1.6.0.0.19 | OK     |
| catalogindex_setup            | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| cataloginventory_setup        | 1.6.0.0.2  | 1.6.0.0.2  | 1.6.0.0.2  | OK     |
| catalogrule_setup             | 1.6.0.3    | 1.6.0.3    | 1.6.0.3    | OK     |
| catalogsearch_setup           | 1.8.2.0    | 1.8.2.0    | 1.8.2.0    | OK     |
| checkout_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| cms_setup                     | 1.6.0.0.2  | 1.6.0.0.2  | 1.6.0.0.2  | OK     |
| compiler_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| contacts_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| core_read                     |            |            |            | OK     |
| core_setup                    | 1.6.0.6    | 1.6.0.6    | 1.6.0.6    | OK     |
| core_write                    |            |            |            | OK     |
| cron_setup                    | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| customer_setup                | 1.6.2.0.3  | 1.6.2.0.3  | 1.6.2.0.3  | OK     |
| dataflow_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| db                            |            |            |            | OK     |
| default_read                  |            |            |            | OK     |
| default_setup                 |            |            |            | OK     |
| default_write                 |            |            |            | OK     |
| directory_setup               | 1.6.0.2    | 1.6.0.2    | 1.6.0.2    | OK     |
| downloadable_setup            | 1.6.0.0.2  | 1.6.0.0.2  | 1.6.0.0.2  | OK     |
| eav_setup                     | 1.6.0.1    | 1.6.0.1    | 1.6.0.1    | OK     |
| giftmessage_setup             | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| googleanalytics_setup         | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| importexport_setup            | 1.6.0.2    | 1.6.0.2    | 1.6.0.2    | OK     |
| index_setup                   | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| log_setup                     | 1.6.1.0    | 1.6.1.0    | 1.6.1.0    | OK     |
| moneybookers_setup            | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| newsletter_setup              | 1.6.0.2    | 1.6.0.2    | 1.6.0.2    | OK     |
| oauth_setup                   | 1.0.0.0    | 1.0.0.0    | 1.0.0.0    | OK     |
| paygate_setup                 | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| payment_setup                 | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| paypal_setup                  | 1.6.0.6    | 1.6.0.6    | 1.6.0.6    | OK     |
| paypaluk_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| persistent_setup              | 1.0.0.0    | 1.0.0.0    | 1.0.0.0    | OK     |
| poll_setup                    | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| productalert_setup            | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| rating_setup                  | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| reports_setup                 | 1.6.0.0.1  | 1.6.0.0.1  | 1.6.0.0.1  | OK     |
| review_setup                  | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| sales_setup                   | 1.6.0.8    | 1.6.0.8    | 1.6.0.8    | OK     |
| salesrule_setup               | 1.6.0.3    | 1.6.0.3    | 1.6.0.3    | OK     |
| sendfriend_setup              | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| shipping_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| sitemap_setup                 | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| tag_setup                     | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| usa_setup                     | 1.6.0.3    | 1.6.0.3    | 1.6.0.3    | OK     |
| weee_setup                    | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| widget_setup                  | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| wishlist_setup                | 1.6.0.0    | 1.6.0.0    | 1.6.0.0    | OK     |
| convenient_categorycode_setup | 0.1.0      | 0.0.9      | 0.0.9      | Error  |
| tax_setup                     | 1.6.0.4    | 1.5.0.0    | 1.5.0.0    | Error  |
+-------------------------------+------------+------------+------------+--------+


  2 errors were found!  
```