### PR TITLE
Hide password when creating admin account.

### DIFF
--- a/src/N98/Magento/Command/Admin/User/CreateUserCommand.php
+++ b/src/N98/Magento/Command/Admin/User/CreateUserCommand.php
@@ -47,7 +47,7 @@ class CreateUserCommand extends AbstractAdminUserCommand
             // Password
             if (($password = $input->getArgument('password')) === null) {
                 $dialog = $this->getHelperSet()->get('dialog');
-                $password = $dialog->ask($output, '<question>Password:</question>');
+                $password = $dialog->askHiddenResponse($output, '<question>Password:</question>');
             }
 
             // Firstname


### PR DESCRIPTION
Use askHiddenResponse to hide the password by default. To maintain
backwards compatability false isn't passed as the final argument. This
means if the terminal doesn't support hidden input plain text will be
used rather than erroring. Closes #60.