### PR TITLE
Fix global options swallowing arguments.

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -156,7 +156,7 @@ class Application extends BaseApplication
         $skipExternalConfig = new InputOption(
             '--skip-config',
             '',
-            InputOption::VALUE_OPTIONAL,
+            InputOption::VALUE_NONE,
             'Do not load any custom config.'
         );
         $inputDefinition->addOption($skipExternalConfig);
@@ -164,7 +164,7 @@ class Application extends BaseApplication
         $skipExternalConfig = new InputOption(
             '--skip-root-check',
             '',
-            InputOption::VALUE_OPTIONAL,
+            InputOption::VALUE_NONE,
             'Do not check if n98-magerun runs as root'
         );
         $inputDefinition->addOption($skipExternalConfig);


### PR DESCRIPTION
The --skip-root-check and --skip-config options were both defined as
InputOption::VALUE_OPTIONAL. In this situation the option will be
assigned the value of an argument that is directly following it. In the
case of a command this is the command name itself, but this causes every
argument to shift along. Since these options are boolean switches, they
can be changed to InputOption::VALUE_NONE. Closes #521.