### PR TITLE
Added display current design settings on particular store

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -104,6 +104,7 @@ commands:
     - N98\Magento\Command\Developer\TemplateHintsCommand
     - N98\Magento\Command\Developer\Theme\DuplicatesCommand
     - N98\Magento\Command\Developer\Theme\ListCommand
+    - N98\Magento\Command\Developer\Theme\InfoCommand
     - N98\Magento\Command\Developer\Translate\InlineAdminCommand
     - N98\Magento\Command\Developer\Translate\InlineShopCommand
     - N98\Magento\Command\Developer\Translate\SetCommand

--- a/src/N98/Magento/Command/Developer/Theme/InfoCommand.php
+++ b/src/N98/Magento/Command/Developer/Theme/InfoCommand.php
@@ -5,32 +5,99 @@ namespace N98\Magento\Command\Developer\Theme;
 use N98\Magento\Command\AbstractMagentoCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
+use N98\Magento\Command\AbstractMagentoStoreConfigCommand;
 
 /**
  * Class InfoCommand
- * @codeCoverageIgnore Command is currently not implemented
  * @package N98\Magento\Command\Developer\Theme
  */
 class InfoCommand extends AbstractMagentoCommand
 {
+    const THEMES_EXCEPTION = '_ua_regexp';
+    
+    protected $_configNodes = array(
+        'Theme translations' => 'design/theme/locale',
+    );
+    
+    protected $_configNodesWithExceptions = array(
+        'Design Package Name' => 'design/package/name',
+        'Theme template' => 'design/theme/template',
+        'Theme skin' => 'design/theme/skin',
+        'Theme layout' => 'design/theme/layout',
+        'Theme default' => 'design/theme/default',
+    );
+    
     protected function configure()
     {
         $this
             ->setName('dev:theme:info')
-            ->addArgument('theme', InputArgument::REQUIRED, 'Your theme')
-            ->setDescription('Infos about a theme');
+            ->setDescription('Displays settings of current design on particular store view');
     }
 
     /**
-     * @param \Symfony\Component\Console\Input\\Symfony\Component\Console\Input\InputInterface $input
-     * @param \Symfony\Component\Console\Output\\Symfony\Component\Console\Output\OutputInterface $output
      * @return int|void
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->detectMagento($output);
-        if ($this->initMagento()) {
+        if ( $this->initMagento() ) {
+            foreach ( \Mage::app()->getWebsites() as $website ) {
+            /* @var $website \Mage_Core_Model_Website */
+                foreach ( $website->getStores() as $store ) {
+                    /* @var $store \Mage_Core_Model_Store */
+                    $this->_displayTable($output, $store);
+                }
+            }
         }
+    }
+    
+    protected function _displayTable(OutputInterface $output, \Mage_Core_Model_Store $store)
+    {
+        $this->writeSection($output, 'Current design setting on store: '. $store->getWebsite()->getCode() . '/' . $store->getCode());
+        $storeInfoLines = $this->_parse($this->_configNodesWithExceptions, $store, true);
+        $storeInfoLines = array_merge($storeInfoLines, $this->_parse($this->_configNodes, $store));
+        
+        $this->getHelper('table')
+                ->setHeaders(array('Parameter', 'Value'))
+                ->renderByFormat($output, $storeInfoLines);
+        
+        return $this;
+    }
+    
+    /**
+     * @return array
+     */
+    protected function _parse(array $nodes, \Mage_Core_Model_Store $store, $withExceptions = false)
+    {
+        $result = array();
+        foreach ( $nodes as $nodeLabel => $node ) {
+            $result[] = array(
+                $nodeLabel, (string)\Mage::getConfig()->getNode($node, AbstractMagentoStoreConfigCommand::SCOPE_STORE_VIEW, $store->getCode())
+            );
+            if ( $withExceptions ) {
+                $result[] = array(
+                    $nodeLabel . ' exceptions', $this->_parseException($node, $store)
+                );
+            }
+        }
+        return $result;
+    }
+    
+    /**
+     * @return string
+     */
+    protected function _parseException($node, \Mage_Core_Model_Store $store)
+    {
+        $exception = (string)\Mage::getConfig()->getNode($node . self::THEMES_EXCEPTION, AbstractMagentoStoreConfigCommand::SCOPE_STORE_VIEW, $store->getCode());
+        if ( empty($exception) ) {
+            return '';
+        }
+        $exceptions = unserialize($exception);
+        $result = array();
+        foreach ( $exceptions as $expression ) {
+            $result[] = 'Matched Expression: ' . $expression['regexp'];
+            $result[] = 'Value: ' . $expression['value'];
+        }
+        return implode("\n", $result);
     }
 }


### PR DESCRIPTION
Hi @tkn98

OK, I am creating new PR, as you asked, this time against `develop` branch.
I can see now, there is 1 commit and 2 files changed, instead of 22 commits to merge :)
I have also changed my repo username, so it will fit now to github account.
Previous PR was: #531 and #534

I am pasting my original message to you guys:
First of all, great work guys with magerun, I can't imagine to work with Magento without Magerun :)

I have proposition of new command to Magerun pack.
I have added command to magerun, which shows current design settings on particular store view.

When developer works on Magento with one store view, he/she simply goes to configuration to obtain design settings.
If store has more than one store view, it is annoying to obtain design settings on all store views.
Command `dev:theme:info` will quickly show design settings to all Magento store views.

I hope this will be useful for people. I can assure you, our frontend team is pleased with this command :)

Greetz, LukeOl