### PR TITLE
Creating a test for rewrite conflict command where a conflict is found

### DIFF
--- a/tests/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommandTest.php
@@ -45,4 +45,66 @@ class ConflictsCommandTest extends TestCase
         $this->assertFileExists('_output.xml');
         @unlink('_output.xml');
     }
+
+    /**
+     * Magento doesn't have any conflicts out of the box, so we need to fake one
+     */
+    public function testExecuteConflict()
+    {
+        $rewrites = array(
+            'blocks' => array(
+                'n98/mock_conflict' => array(
+                    'Mage_Customer_Block_Account',
+                    'Mage_Tag_Block_All',
+                )
+            )
+        );
+        $command = $this->getCommandWithMockLoadRewrites($rewrites);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+        $this->assertContains('1 conflict was found', $commandTester->getDisplay());
+    }
+
+    /**
+     * This is made to look like a conflict (2 rewrites for the same class) but 
+     * because Bundle extends Catalog, it's valid.  Note that we're implying
+     * Bundle depends on Catalog by passing it as the second value in the array.
+     */
+    public function testExecuteConflictFalsePositive()
+    {
+        $rewrites = array(
+            'blocks' => array(
+                'n98/mock_conflict' => array(
+                    'Mage_Catalog_Block_Product_Price',
+                    'Mage_Bundle_Block_Catalog_Product_Price',
+                )
+            )
+        );
+        $command = $this->getCommandWithMockLoadRewrites($rewrites);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+        $this->assertContains('No rewrite conflicts were found', $commandTester->getDisplay());
+    }
+
+    /**
+     * Mock the ConflictsCommand and change the return value of loadRewrites()
+     * to the given argument
+     *
+     * @param  array            $return
+     * @return ConflictsCommand
+     */
+    private function getCommandWithMockLoadRewrites(array $return)
+    {
+        $commandMock = $this->getMockBuilder('N98\Magento\Command\Developer\Module\Rewrite\ConflictsCommand')
+            ->setMockClassName('ConflictsCommandMock')
+            ->enableOriginalClone()
+            ->setMethods(array('loadRewrites'))
+            ->getMock();
+        $this->getApplication()->add($commandMock);
+        $commandMock
+            ->expects($this->any())
+            ->method('loadRewrites')
+            ->will($this->returnValue($return));
+        return $commandMock;
+    }
 }


### PR DESCRIPTION
Inspired by discussion in issue #523, this adds an option `--mock-conflict` to mock a positive conflict detection while testing:

```
$ magerun dev:module:rewrite:conflict --mock-conflict

┌────────┬──────────────────────────────┬────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
│blocks  │n98/mock                      │Mage_Customer_Block_Account, Mage_Tag_Block_All             │Mage_N98_Block_Mock                                         │
└────────┴──────────────────────────────┴────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘
1 conflict was found!
```

I used `Mage_Customer_Block_Account` and `Mage_Tag_Block_All` as the guinea pigs since I needed classes that actually existed, but `Mage_N98_Block_Mock` lets the user know it's fake.

Travis is still going nuts so [you probably can't see the test in action](https://travis-ci.org/steverobbins/n98-magerun/builds/60574572).  Testing locally on PHP 5.5 worked, however

```
$ N98_MAGERUN_TEST_MAGENTO_ROOT=~/html/magento ~/n98-magerun/vendor/bin/phpunit --debug -c ~/n98-magerun/phpunit.xml --filter=Conflicts
PHPUnit 4.1.6-3-g9790627 by Sebastian Bergmann.

Configuration read from /home/user/n98-magerun/phpunit.xml


Starting test 'N98\Magento\Command\Developer\Module\Rewrite\ConflictsCommandTest::testExecute'.
.
Starting test 'N98\Magento\Command\Developer\Module\Rewrite\ConflictsCommandTest::testExecuteMockConflict'.
.

Time: 26.83 seconds, Memory: 52.00Mb

OK (2 tests, 4 assertions)

Generating code coverage report in Clover XML format ... done
```

Note that this could start breaking builds as it aims to expose the issue in #523, but would be fixed with PR #528.