### PR TITLE
Improve observer list accuracy.

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Observer/ListCommand.php
@@ -82,7 +82,13 @@ class ListCommand extends AbstractMagentoCommand
                 $observerList = array();
                 foreach ($eventData['observers'] as $observer) {
                     $observerType   = $this->getObserverType($observer, $type);
-                    $observerList[] = $observerType . $observer['class'] . (isset($observer['method']) ? '::' . $observer['method'] : '');
+                    $class = '';
+                    if (isset($observer['class'])) {
+                        $class = $observer['class'];
+                    } elseif (isset($observer['model'])) {
+                        $class = $observer['model'];
+                    }
+                    $observerList[] = $observerType . $class . (isset($observer['method']) ? '::' . $observer['method'] : '');
                 }
                 $table[] = array(
                     $eventName,


### PR DESCRIPTION
If the class node isn't set in the configuration for an observer,
Magento will also check for the model node. Added support for this to
the list command.