### PR TITLE
updated n98-magerun customer delete to delete payment profiles

### DIFF
--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -61,7 +61,11 @@ HELP;
             
             $res = $this->getCustomerModel()->getResource();
             
-            $faker = \Faker\Factory::create($input->getArgument('locale'));
+            $locale = $input->getArgument('locale');
+            $faker = \Faker\Factory::create($locale);
+            $faker->locale = $locale;
+            $faker->languageCode = substr($locale, 0, 2); // the first two characters of $locale
+            $faker->countryCode = substr($locale, 3, 2);  // the 4th and 5th characters of $locale
             $faker->addProvider(new \N98\Util\Faker\Provider\Internet($faker));
 
             $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);

--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -221,7 +221,13 @@ HELP;
      */
     protected function deleteCustomer(\Mage_Customer_Model_Customer $customer)
     {
+        require_once $this->getApplication()->getMagentoRootFolder() . '/app/code/local/SFC/CyberSource/controllers/Override/Admin/CustomerController.php';
+
         try {
+            $customerId = $customer->getId();
+            $customerController = new \SFC_CyberSource_Override_Admin_CustomerController();
+            $customerController->deletePaymentProfiles($customerId);
+            
             $customer->delete();
             $this->output->writeln(
                 sprintf('<info>%s (%s) was successfully deleted</info>', $customer->getName(), $customer->getEmail())


### PR DESCRIPTION
In our system, you cannot delete a customer until you have first deleted all of their payment profiles.