### PR TITLE
respect the locale set by the user

### DIFF
--- a/src/N98/Magento/Command/Customer/CreateDummyCommand.php
+++ b/src/N98/Magento/Command/Customer/CreateDummyCommand.php
@@ -61,7 +61,11 @@ HELP;
             
             $res = $this->getCustomerModel()->getResource();
             
-            $faker = \Faker\Factory::create($input->getArgument('locale'));
+            $locale = $input->getArgument('locale');
+            $faker = \Faker\Factory::create($locale);
+            $faker->locale = $locale;
+            $faker->languageCode = substr($locale, 0, 2); // the first two characters of $locale
+            $faker->countryCode = substr($locale, 3, 2);  // the 4th and 5th characters of $locale
             $faker->addProvider(new \N98\Util\Faker\Provider\Internet($faker));
 
             $website = $this->getHelperSet()->get('parameter')->askWebsite($input, $output);


### PR DESCRIPTION
Faker, unfortunately, doesn't seem to be respecting the locale information it receives.  It is setting the countryCode and languageCode (and locale) randomly.  This means that even though I ran 
*n98-magerun customer:create:dummy 1 en_US 1*
my customer ends up in a random country.