### PR TITLE
reset magento root folder in `N98\Magento\Application::reinit`

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -704,6 +704,8 @@ class Application extends BaseApplication
     public function reinit($initConfig = array(), InputInterface $input = null, OutputInterface $output = null)
     {
         $this->_isInitialized = false;
+        $this->_magentoDetected = false;
+        $this->_magentoRootFolder = null;
         $this->init($initConfig, $input, $output);
     }
 


### PR DESCRIPTION
I think it would make sense to re-initialize the magento root folder in the `reinit` method. This is prevented by the flag `$_magentoDetected`.
This behaviour caused some errors in the "install" command, which changes into the root folder, calls the `reinit` method, and runs two more commands.

To reproduce the problem:

* extract sources to a subfolder "public"
* from the "public"'s parent, run n98-magerun (with --noDownload option, and --installationFolder=public)

What happens:
* The installation itself succeeds, the detected root folder is "public" (relative path)
* ` \chdir($this->config['installationFolder']);` is called
* `$this->getApplication()->reinit();` is called, but the `_magentoRootFolder` is not updated
* The reindexAll command is run. During `\N98\Magento\Application::_initMagento1`, the statement `require_once $this->getMagentoRootFolder() . '/app/Mage.php';` causes an error: "Failed opening required 'public/app/Mage.php' ..."