### PR TITLE
Excluding wishlist tables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -346,7 +346,7 @@ commands:
 
       - id: customers
         description: Customer data - Should not be used without @sales
-        tables: customer_address* customer_entity*
+        tables: customer_address* customer_entity* wishlist*
 
       - id: newsletter
         description: Newsletter subscriber data


### PR DESCRIPTION
The Magento wishlist tables include a foreign key to the customer data tables. If those customer data tables are not included, the wishlist data is basically useless.

This PR excludes the wishlist tables from the database dump when the `@customers` table group is used in the `--strip` option.