### PR TITLE
Checksum for package downloads

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -170,6 +170,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.9.1.1/magento-1.9.1.1.tar.gz
           type: tar
+          shasum: 170e4b9019f43477d2f2a074ef551a05009da724
         extra:
           sample-data: sample-data-1.9.1.0
 
@@ -178,6 +179,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.9.1.0/magento-1.9.1.0.tar.gz
           type: tar
+          shasum: 4f7064f4a5bc46298979e8b37208be6fdaf20002
         extra:
           sample-data: sample-data-1.9.1.0
 
@@ -186,6 +188,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.9.0.1/magento-1.9.0.1.tar.gz
           type: tar
+          shasum: 5100c4dab56cf587d5478b9bf8b5d4a0fa411179
         extra:
           sample-data: sample-data-1.9.0.0
 
@@ -194,6 +197,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.8.1.0/magento-1.8.1.0.tar.gz
           type: tar
+          shasum: 024a6173003e4f6814e7fb7e84ca8b08a18db4c1
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -202,6 +206,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.8.0.0/magento-1.8.0.0.tar.gz
           type: tar
+          shasum: 31a52e9522d09065ff6f939faa1289023db2eff5
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -210,6 +215,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.7.0.2/magento-1.7.0.2.tar.gz
           type: tar
+          shasum: 8d2a378e92ee917a3b74b1a51a8d3e6874dc6ab9
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -218,6 +224,7 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.6.2.0/magento-1.6.2.0.tar.gz
           type: tar
+          shasum: 897050f0c08480ab6531eead5a5caadfef673340
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -226,6 +233,7 @@ commands:
         dist:
           url: https://github.com/LokeyCoding/magento-mirror/archive/1.7.0.2.tar.gz
           type: tar
+          shasum: c10a3e15f9311c2b079bb2e71bacb32cb3192402
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -234,6 +242,7 @@ commands:
         dist:
           url: https://github.com/LokeyCoding/magento-mirror/archive/1.6.2.0.tar.gz
           type: tar
+          shasum: 301b815359b8abd4dfcd828b261cd924d9868a19
         extra:
           sample-data: sample-data-1.6.1.0
 
@@ -270,24 +279,28 @@ commands:
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.9.1.0/magento-sample-data-1.9.1.0.tar.gz
           type: tar
+          shasum: 617e0271900772ac8f11e7bb86e29fca0f640562
 
       - name: sample-data-1.9.0.0
         version: 1.9.0.0
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.9.0.0/magento-sample-data-1.9.0.0.tar.gz
           type: tar
+          shasum: b2b535901eb2db92a8602baf8a839ab2120c4c8f
 
       - name: sample-data-1.6.1.0
         version: 1.6.1.0
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.6.1.0/magento-sample-data-1.6.1.0.tar.gz
           type: tar
+          shasum: a9226bc92966855327f6eb62ff8f6c562b2113a2
 
       - name: sample-data-1.1.2
         version: 1.1.2
         dist:
           url: http://www.magentocommerce.com/downloads/assets/1.1.2/magento-sample-data-1.1.2.tar.bz2
           type: tar
+          shasum: e8ddbf94698224fb71c946e789f7a23dec236384
 
     installation:
       pre-check:

--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -126,7 +126,11 @@ HELP;
         $this->chooseInstallationFolder($input, $output);
 
         if (!$input->getOption('noDownload')) {
-            $this->downloadMagento($input, $output);
+            $result = $this->downloadMagento($input, $output);
+
+            if ($result === false) {
+                return 1;
+            }
         }
 
         if ($input->getOption('only-download')) {


### PR DESCRIPTION
Downloads were not verified against a checksum. This has been fixed by introducing a checksum for each package.

- SHA checksums for download packages.
- exit with error when download fails (e.g. due to failed checksum validation).

I generated the checksums on my box with shasum. In case there is a mismatch, please peer review them. Download URLs from the config.yaml file, downloaded with wget.