### PR TITLE
add Magento CE 1.9.2.0 (OpenMage Mirror)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -220,6 +220,14 @@ commands:
         extra:
           sample-data: sample-data-1.6.1.0
 
+      - name: magento-mirror-1.9.2.0
+        version: 1.9.2.0
+        dist:
+          url: https://github.com/LokeyCoding/magento-mirror/archive/1.9.2.0.tar.gz
+          type: tar
+        extra:
+          sample-data: sample-data-1.9.1.0
+
       - name: magento-mirror-1.7.0.2
         version: 1.7.0.2
         dist:


### PR DESCRIPTION
this PR adds Magento CE 1.9.2.0 via https://github.com/OpenMage/magento-mirror until we have a way to load the official files directly.