### PR TITLE
Validate cache codes on cache enable, disable and clean.

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -70,24 +70,6 @@ abstract class AbstractMagentoCommand extends Command
         $this->checkDeprecatedAliases($input, $output);
     }
 
-    /**
-     * @param array $codeArgument
-     * @param bool  $status
-     * @return bool
-     */
-    protected function saveCacheStatus($codeArgument, $status)
-    {
-        $cacheTypes = $this->_getCacheModel()->getTypes();
-        $enable = \Mage::app()->useCache();
-        foreach ($cacheTypes as $cacheCode => $cacheModel) {
-            if (empty($codeArgument) || in_array($cacheCode, $codeArgument)) {
-                $enable[$cacheCode] = $status ? 1 : 0;
-            }
-        }
-
-        \Mage::app()->saveUseCache($enable);
-    }
-
     private function _initWebsites()
     {
         $this->_websiteCodeMap = array();

--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -263,8 +263,8 @@ abstract class AbstractMagentoCommand extends Command
     /**
      * brings locally cached repository up to date if it is missing the requested tag
      *
-     * @param $package
-     * @param $targetFolder
+     * @param PackageInterface $package
+     * @param string $targetFolder
      */
     protected function checkRepository($package, $targetFolder)
     {
@@ -509,11 +509,11 @@ abstract class AbstractMagentoCommand extends Command
     }
 
     /**
-     * @param $argument
+     * @param string $argument
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @param null $message
-     * @return mixed
+     * @param string $message
+     * @return string
      */
     protected function getOrAskForArgument($argument, InputInterface $input, OutputInterface $output, $message = null)
     {

--- a/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
+++ b/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
@@ -22,6 +22,24 @@ class AbstractCacheCommand extends AbstractMagentoCommand
     }
 
     /**
+     * @param array $codeArgument
+     * @param bool  $status
+     * @return boolean|null
+     */
+    protected function saveCacheStatus($codeArgument, $status)
+    {
+        $cacheTypes = $this->_getCacheModel()->getTypes();
+        $enable = \Mage::app()->useCache();
+        foreach ($cacheTypes as $cacheCode => $cacheModel) {
+            if (empty($codeArgument) || in_array($cacheCode, $codeArgument)) {
+                $enable[$cacheCode] = $status ? 1 : 0;
+            }
+        }
+
+        \Mage::app()->saveUseCache($enable);
+    }
+
+    /**
      * Ban cache usage before cleanup to get the latest values.
      *
      * @see https://github.com/netz98/n98-magerun/issues/483

--- a/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
+++ b/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
@@ -28,6 +28,8 @@ class AbstractCacheCommand extends AbstractMagentoCommand
      */
     protected function saveCacheStatus($codeArgument, $status)
     {
+        $this->validateCacheCodes($codeArgument);
+
         $cacheTypes = $this->_getCacheModel()->getTypes();
         $enable = \Mage::app()->useCache();
         foreach ($cacheTypes as $cacheCode => $cacheModel) {
@@ -37,6 +39,20 @@ class AbstractCacheCommand extends AbstractMagentoCommand
         }
 
         \Mage::app()->saveUseCache($enable);
+    }
+
+    /**
+     * @param array $codes
+     * @throws \InvalidArgumentException
+     */
+    protected function validateCacheCodes(array $codes)
+    {
+        $cacheTypes = $this->_getCacheModel()->getTypes();
+        foreach ($codes as $cacheCode) {
+            if (!array_key_exists($cacheCode, $cacheTypes)) {
+                throw new \InvalidArgumentException('Invalid cache type: ' . $cacheCode);
+            }
+        }
     }
 
     /**

--- a/src/N98/Magento/Command/Cache/CleanCommand.php
+++ b/src/N98/Magento/Command/Cache/CleanCommand.php
@@ -46,6 +46,7 @@ HELP;
             \Mage::app()->loadAreaPart('adminhtml', 'events');
             $allTypes = \Mage::app()->useCache();
             $typesToClean = $input->getArgument('type');
+            $this->validateCacheCodes($typesToClean);
             $typeKeys = array_keys($allTypes);
 
             foreach ($typeKeys as $type) {


### PR DESCRIPTION
### Current functionality
```
n98-magerun.phar cache:disable eavv
Cache eavv disabled
```
### New functionality
```
n98-magerun.phar cache:disable eavv
           
  [InvalidArgumentException]  
  Invalid cache type: eavv    
                              
cache:disable [code]
```

Same for `cache:enable` and `cache:clean`.

Solves issue #620 