### PR TITLE
Fix fatal error on string operation

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -555,9 +555,9 @@ abstract class AbstractMagentoCommand extends Command
     protected function askForArrayEntry(array $entries, OutputInterface $output, $question)
     {
         foreach ($entries as $key => $entry) {
-            $question[] = '<comment>[' . ($key + 1) . ']</comment> ' . $entry . "\n";
+            $question .= '<comment>[' . ($key + 1) . ']</comment> ' . $entry . "\n";
         }
-        $question[] = "<question>{$question}</question> ";
+        $question .= "<question>{$question}</question> ";
 
         $selected = $this->getHelper('dialog')->askAndValidate($output, $question, function($typeInput) use ($entries) {
             if (!in_array($typeInput, range(1, count($entries)))) {


### PR DESCRIPTION
An operation on a string variable caused a fatal error because of using an array operator on string (array push operator).

This has been fixed by using the string concatenation operator.

Fixes #632