### PR TITLE
Fix: Dump command was showing duplicate help

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -48,31 +48,6 @@ You must have installed the MySQL client tools.
 On debian systems run `apt-get install mysql-client` to do that.
 
 The command reads app/etc/local.xml to find the correct settings.
-If you like to skip data of some tables you can use the --strip option.
-The strip option creates only the structure of the defined tables and
-forces `mysqldump` to skip the data.
-
-Dumps your database and excludes some tables. This is useful i.e. for development.
-
-Separate each table to strip by a space.
-You can use wildcards like * and ? in the table names to strip multiple tables.
-In addition you can specify pre-defined table groups, that start with an @
-Example: "dataflow_batch_export unimportant_module_* @log
-
-   $ n98-magerun.phar db:dump --strip="@stripped"
-
-Available Table Groups:
-
-* @log Log tables
-* @dataflowtemp Temporary tables of the dataflow import/export tool
-* @importexporttemp Temporary tables of the Import/Export module
-* @stripped Standard definition for a stripped dump (logs, dataflow and importexport)
-* @sales Sales data (orders, invoices, creditmemos etc)
-* @customers Customer data
-* @trade Current trade data (customers and orders). You usally do not want those in developer systems.
-* @development Removes logs and trade data so developers do not have to work with real customer data
-
-Extended: https://github.com/netz98/n98-magerun/wiki/Stripped-Database-Dumps
 
 See it in action: http://youtu.be/ttjZHY6vThs
 
@@ -137,17 +112,24 @@ HELP;
      */
     public function getTableDefinitionHelp()
     {
-        $messages = array();
+        $messages = PHP_EOL;;
         $this->commandConfig = $this->getCommandConfig();
-        $messages[] = '';
-        $messages[] = '<comment>Strip option</comment>';
-        $messages[] = ' Separate each table to strip by a space.';
-        $messages[] = ' You can use wildcards like * and ? in the table names to strip multiple tables.';
-        $messages[] = ' In addition you can specify pre-defined table groups, that start with an @';
-        $messages[] = ' Example: "dataflow_batch_export unimportant_module_* @log';
-        $messages[] = '';
-        $messages[] = '<comment>Available Table Groups</comment>';
+        $messages .= <<<HELP
+<comment>Strip option</comment>
+ If you like to skip data of some tables you can use the --strip option.
+  The strip option creates only the structure of the defined tables and
+ forces `mysqldump` to skip the data.
 
+ Separate each table to strip by a space.
+ You can use wildcards like * and ? in the table names to strip multiple tables.
+ In addition you can specify pre-defined table groups, that start with an @
+ Example: "dataflow_batch_export unimportant_module_* @log
+
+    $ n98-magerun.phar db:dump --strip="@stripped"
+
+<comment>Available Table Groups</comment>
+
+HELP;
         $definitions = $this->getTableDefinitions();
         foreach ($definitions as $id => $definition) {
             $description = isset($definition['description']) ? $definition['description'] : '';
@@ -155,10 +137,10 @@ HELP;
              * Column-Wise formatting of the options, see InputDefinition::asText for code to pad by the max length,
              * but I do not like to copy and paste ..
              */
-            $messages[] = ' <info>@' . $id . '</info> ' . $description;
+            $messages .= ' <info>@' . $id . '</info> ' . $description . PHP_EOL;
         }
 
-        return implode(PHP_EOL, $messages);
+        return $messages;
     }
 
     public function getHelp()


### PR DESCRIPTION
The table group help is autogenerated.
Additionally it was in the static help block.

The documentation was fixed.