### PR TITLE
[BUGFIX] #643 fatal error in customer:delete

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -6,6 +6,7 @@ RECENT CHANGES
 1.97.5
 ======
 
+* #643 Fix fatal error in customer:delete (by Tom Klingenberg)
 * #640 Fix db:dump duplicate help (by Alexander Menk)
 * #616 Add db:dump exclude option (by Alexander Menk)
 * Add js and css merging commands (by Simon Sippert)

--- a/src/N98/Magento/Command/Customer/AbstractCustomerCommand.php
+++ b/src/N98/Magento/Command/Customer/AbstractCustomerCommand.php
@@ -2,6 +2,11 @@
 
 namespace N98\Magento\Command\Customer;
 
+use Mage_Customer_Model_Address;
+use Mage_Customer_Model_Customer;
+use Mage_Customer_Model_Resource_Customer_Collection;
+use Mage_Directory_Model_Resource_Country_Collection;
+use Mage_Directory_Model_Resource_Region_Collection;
 use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\Exec;
 
@@ -21,7 +26,7 @@ abstract class AbstractCustomerCommand extends AbstractMagentoCommand
     }
 
     /**
-     * @return \Mage_Customer_Model_Resource_Customer_Collection
+     * @return Mage_Customer_Model_Resource_Customer_Collection
      */
     protected function getCustomerCollection()
     {
@@ -29,7 +34,7 @@ abstract class AbstractCustomerCommand extends AbstractMagentoCommand
     }
 
     /**
-     * @return \Mage_Customer_Model_Address
+     * @return Mage_Customer_Model_Address
      */
     protected function getAddressModel()
     {
@@ -37,7 +42,7 @@ abstract class AbstractCustomerCommand extends AbstractMagentoCommand
     }
 
     /**
-     * @return \Mage_Directory_Model_Resource_Region_Collection
+     * @return Mage_Directory_Model_Resource_Region_Collection
      */
     protected function getRegionCollection()
     {
@@ -45,7 +50,7 @@ abstract class AbstractCustomerCommand extends AbstractMagentoCommand
     }
 
     /**
-     * @return \Mage_Directory_Model_Resource_Country_Collection
+     * @return Mage_Directory_Model_Resource_Country_Collection
      */
     protected function getCountryCollection()
     {

--- a/src/N98/Magento/Command/Customer/DeleteCommand.php
+++ b/src/N98/Magento/Command/Customer/DeleteCommand.php
@@ -2,6 +2,8 @@
 
 namespace N98\Magento\Command\Customer;
 
+use N98\Util\Console\Helper\ParameterHelper;
+use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,7 +27,7 @@ class DeleteCommand extends AbstractCustomerCommand
     protected $output;
 
     /**
-     * @var  \Composer\Command\Helper\DialogHelper
+     * @var DialogHelper
      */
     protected $dialog;
 
@@ -67,9 +69,10 @@ HELP;
         $this->detectMagento($output, true);
         if ($this->initMagento()) {
 
-            $this->input    = $input;
-            $this->output   = $output;
-            $this->dialog   = $this->getHelperSet()->get('dialog');
+            $this->input  = $input;
+            $this->output = $output;
+            /** @var DialogHelper dialog */
+            $this->dialog = $this->getHelperSet()->get('dialog');
 
             // Defaults
             $range = $all = false;
@@ -83,7 +86,7 @@ HELP;
                 // Delete more than one customer ?
                 $batchDelete = $this->dialog->askConfirmation(
                     $this->output,
-                    $this->dialog->getQuestion('Delete more than 1 customer?', 'n'),
+                    $this->getQuestion('Delete more than 1 customer?', 'n'),
                     false
                 );
 
@@ -91,14 +94,14 @@ HELP;
                     // Batch deletion
                     $all = $this->dialog->askConfirmation(
                         $this->output,
-                        $this->dialog->getQuestion('Delete all customers?', 'n'),
+                        $this->getQuestion('Delete all customers?', 'n'),
                         false
                     );
 
                     if (!$all) {
                         $range = $this->dialog->askConfirmation(
                             $this->output,
-                            $this->dialog->getQuestion('Delete a range of customers?', 'n'),
+                            $this->getQuestion('Delete a range of customers?', 'n'),
                             false
                         );
 
@@ -114,7 +117,7 @@ HELP;
             if (!$range && !$all) {
                 // Single customer deletion
                 if (!$id) {
-                    $id = $this->dialog->ask($this->output, $this->dialog->getQuestion('Customer Id'), null);
+                    $id = $this->dialog->ask($this->output, $this->getQuestion('Customer Id'), null);
                 }
 
                 try {
@@ -132,7 +135,8 @@ HELP;
                 }
             } else {
 
-                $customers = $this->getCustomerCollection()
+                $customers = $this->getCustomerCollection();
+                $customers
                     ->addAttributeToSelect('firstname')
                     ->addAttributeToSelect('lastname')
                     ->addAttributeToSelect('email');
@@ -142,14 +146,14 @@ HELP;
                     $ranges = array();
                     $ranges[0] = $this->dialog->askAndValidate(
                         $this->output,
-                        $this->dialog->getQuestion('Range start Id', '1'),
+                        $this->getQuestion('Range start Id', '1'),
                         array($this, 'validateInt'),
                         false,
                         '1'
                     );
                     $ranges[1] = $this->dialog->askAndValidate(
                         $this->output,
-                        $this->dialog->getQuestion('Range end Id', '1'),
+                        $this->getQuestion('Range end Id', '1'),
                         array($this, 'validateInt'),
                         false,
                         '1'
@@ -184,7 +188,7 @@ HELP;
         if (!$shouldRemove) {
             $shouldRemove = $this->dialog->askConfirmation(
                 $this->output,
-                $this->dialog->getQuestion('Are you sure?', 'n'),
+                $this->getQuestion('Are you sure?', 'n'),
                 false
             );
         }
@@ -199,10 +203,12 @@ HELP;
      */
     protected function getCustomer($id)
     {
-        // Get customer
+        /** @var \Mage_Customer_Model_Customer $customer */
         $customer = $this->getCustomerModel()->load($id);
         if (!$customer->getId()) {
-            $website = $this->getHelperSet()->get('parameter')->askWebsite($this->input, $this->output);
+            /** @var $parameterHelper ParameterHelper */
+            $parameterHelper = $this->getHelperSet()->get('parameter');
+            $website = $parameterHelper->askWebsite($this->input, $this->output);
             $customer = $this->getCustomerModel()
                 ->setWebsiteId($website->getId())
                 ->loadByEmail($id);
@@ -262,5 +268,25 @@ HELP;
         }
 
         return $answer;
+    }
+
+    /**
+     * @param string $message
+     * @param string $default [optional]
+     *
+     * @return string
+     */
+    private function getQuestion($message, $default = null)
+    {
+        $params  = array($message);
+        $pattern = '%s: ';
+
+        if (null !== $default) {
+            $params[] = $default;
+            $pattern .= '[%s] ';
+
+        }
+
+        return vsprintf($pattern, $params);
     }
 }


### PR DESCRIPTION
In b5c7137 the customer:delete command was introducted. It made use of an
Dialog helper that had the getQuestion() method.

The current Dialog helper does not have such a method any longer. Now the
Dialog helper is:

   Symfony\Component\Console\Helper\DialogHelper

which is deprecated.

Fix is to not call that method any longer. Instead a private helper
method is called which returns the string of the question.

Closes #643