### PR TITLE
Fix for PHP warning in Rewrite command

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Rewrite/AbstractRewriteCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/AbstractRewriteCommand.php
@@ -21,9 +21,9 @@ abstract class AbstractRewriteCommand extends AbstractMagentoCommand
     protected function loadRewrites()
     {
         $return = array(
-            'blocks',
-            'models',
-            'helpers',
+            'blocks'  => array(),
+            'models'  => array(),
+            'helpers' => array(),
         );
 
         // Load config of each module because modules can overwrite config each other. Globl config is already merged


### PR DESCRIPTION
We sometimes see this PHP warning in our system.log files of Magento:

```
Warning: Invalid argument supplied for foreach()  in n98-magerun.phar/src/N98/Magento/Command/Developer/Module/Rewrite/ListCommand.php on line 41
```

This PR fixes this.

The problem is that the `$return` array is initialized with values, instead of keys. The resulting array then looks something like this:
```php
array(7) {
  [0] =>
  string(6) "blocks"
  [1] =>
  string(6) "models"
  [2] =>
  string(7) "helpers"
  'models' =>
  array(36) {
    'compiler/process' =>
    array(1) {
      [0] =>
      string(40) "Aitoc_Aitsys_Model_Core_Compiler_Process"
    }
    'catalog_resource_eav_mysql4/category_tree' =>
    array(1) {
      [0] =>
      string(76) "Aitoc_Aitpermissions_Model_Rewrite_CatalogModelResourceEavMysql4CategoryTree"
    }
...
```

You can see the first 3 values are incorrect, that's why the foreach in the ListCommand class is complaining about the `$data` variable not being an array.


This fixes #438 for real :).


(sorry for my commit message, it's not really correct, I only fully understood the problem while writing this PR :))