### PR TITLE
[FIX] add wrapCdata test

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -6,6 +6,7 @@ RECENT CHANGES
 1.97.6
 ======
 
+* #664 Fix GenerateCommand::wrapCdata (by Tom Klingenberg)
 * #669 Fix Magerun2 download instructions (by Pierre du Plessis)
 * #665 Fix Magento 1.9.2.1 announced as 1.9.2.0 (reported by jurgisl)
 * #657 Fix and improve input processing in "local-config:generate" command (by Aydin Hassan)

--- a/src/N98/Magento/Command/LocalConfig/GenerateCommand.php
+++ b/src/N98/Magento/Command/LocalConfig/GenerateCommand.php
@@ -143,15 +143,21 @@ HELP;
     }
 
     /**
-     * @param string $value
-     * @return string
+     * wrap utf-8 string as a <![CDATA[ ... ]]> section if the string has length.
+     *
+     * in case the string has length and not the whole string can be wrapped in a CDATA section (because it contains
+     * a sequence that can not be part of a CDATA section "]]>") the part that can well be.
+     *
+     * @param string $string
+     *
+     * @return string CDATA section or equivalent
      */
-    protected function _wrapCData($value)
+    protected function _wrapCData($string)
     {
-        if (!strstr($value, 'CDATA')) {
-            return '<![CDATA[' . $value . ']]>';
-        }
+        $buffer = strtr($string, array(']]>' => ']]>]]&gt;<![CDATA['));
+        $buffer = '<![CDATA[' . $buffer . ']]>';
+        $buffer = strtr($buffer, array('<![CDATA[]]>' => ''));
 
-        return $value;
+        return $buffer;
     }
 }

--- a/tests/N98/Magento/Command/LocalConfig/GenerateCommandTest.php
+++ b/tests/N98/Magento/Command/LocalConfig/GenerateCommandTest.php
@@ -336,7 +336,7 @@ class GenerateCommandTest extends TestCase
         $fileContent = \file_get_contents($this->configFile);
         $this->assertContains('<host><![CDATA[my_db_host]]></host>', $fileContent);
         $this->assertContains('<username><![CDATA[my_db_user]]></username>', $fileContent);
-        $this->assertContains('<password><![CDATA[]]></password>', $fileContent);
+        $this->assertContains('<password></password>', $fileContent);
         $this->assertContains('<dbname><![CDATA[my_db_name]]></dbname>', $fileContent);
         $this->assertContains('<session_save><![CDATA[my_session_save]]></session_save>', $fileContent);
         $this->assertContains('<frontName><![CDATA[my_admin_frontname]]></frontName>', $fileContent);
@@ -376,7 +376,7 @@ class GenerateCommandTest extends TestCase
 
         $this->assertFileExists($this->configFile);
         $fileContent = \file_get_contents($this->configFile);
-        $this->assertContains('<host>CDATAdatabasehost</host>', $fileContent);
+        $this->assertContains('<host><![CDATA[CDATAdatabasehost]]></host>', $fileContent);
         $this->assertContains('<username><![CDATA[my_db_user]]></username>', $fileContent);
         $this->assertContains('<password><![CDATA[my_db_pass]]></password>', $fileContent);
         $this->assertContains('<dbname><![CDATA[my_db_name]]></dbname>', $fileContent);
@@ -385,6 +385,27 @@ class GenerateCommandTest extends TestCase
         $this->assertContains('<key><![CDATA[key123456789]]></key>', $fileContent);
         $xml = \simplexml_load_file($this->configFile);
         $this->assertNotInternalType('bool', $xml);
+    }
+
+    /**
+     * @test unit utility method _wrapCdata
+     */
+    public function wrapCdata()
+    {
+        $command = new GenerateCommand();
+        $refl = new \ReflectionClass($command);
+        $method = $refl->getMethod('_wrapCData');
+        $method->setAccessible(true);
+        $sujet = function($string) use ($method, $command) {
+            return $method->invoke($command, $string);
+        };
+
+        $this->assertSame('', $sujet(null));
+        $this->assertSame('<![CDATA[CDATA]]>', $sujet('CDATA'));
+        $this->assertSame('<![CDATA[]]]]>', $sujet(']]'));
+        $this->assertSame('<![CDATA[ with terminator "]]>]]&gt;<![CDATA[" inside ]]>', $sujet(' with terminator "]]>" inside '));
+        $this->assertSame(']]&gt;<![CDATA[ at the start ]]>', $sujet(']]> at the start '));
+        $this->assertSame('<![CDATA[ at the end ]]>]]&gt;', $sujet(' at the end ]]>'));
     }
 
     public function tearDown()


### PR DESCRIPTION
the GenerateCommand has problems properly wrapping a string into a CDATA section when it comes to strings containing the word "CDATA" or "]]>".