### PR TITLE
Disable coverage generation by default, enable specifically for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,5 @@ before_script:
   - source ./build/travis/before_script.sh
 
 script:
-  - vendor/bin/phpunit --debug --stop-on-error --stop-on-failure
+  - vendor/bin/phpunit --debug --stop-on-error --stop-on-failure --coverage-clover=clover.xml
   - php tests/check-coverage.php clover.xml ${COVERAGE}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,4 @@
             </exclude>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-clover" target="./clover.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
Running tests locally is horribly slow. I removed the default coverage generation and specifically enabled for travis.

This reduces tests elapsed time from over 10 minutes to 1 minute on my local machine. I think if you want coverage generation then you should specifically ask for it. In any case clover format is mostly useless to us developers. If you want coverage metrics you should just run `vendor/bin/phpunit --coverage-text`

I think we should also refactor travis to only generate coverage for maybe 1 version of php. Currently it's far too slow. 