### PR TITLE
WIP - Separate test suite for Uninstall command

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,9 +15,13 @@
          stopOnSkipped="false"
          strict="false">
     <testsuites>
-        <testsuite name="n98-magerun Tests">
+        <testsuite name="n98-magerun-tests">
             <directory>./tests</directory>
+            <exclude>tests/N98/Magento/Command/Installer/UninstallCommandTest.php</exclude>
         </testsuite>
+      <testsuite name="n98-magerun-magento-uninstall-tests">
+          <file>./tests/N98/Magento/Command/Installer/UninstallCommandTest.php</file>
+      </testsuite>
     </testsuites>
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">

--- a/src/N98/Magento/Command/PHPUnit/TestCase.php
+++ b/src/N98/Magento/Command/PHPUnit/TestCase.php
@@ -19,6 +19,11 @@ class TestCase extends \PHPUnit_Framework_TestCase
     private $application = null;
 
     /**
+     * @var string|null
+     */
+    private $root;
+
+    /**
      * getter for the magento root directory of the test-suite
      *
      * @see ApplicationTest::testExecute
@@ -27,6 +32,10 @@ class TestCase extends \PHPUnit_Framework_TestCase
      */
     public function getTestMagentoRoot()
     {
+        if ($this->root) {
+            return $this->root;
+        }
+
         $root = getenv('N98_MAGERUN_TEST_MAGENTO_ROOT');
         if (empty($root)) {
             $this->markTestSkipped(
@@ -35,7 +44,8 @@ class TestCase extends \PHPUnit_Framework_TestCase
             );
         }
 
-        return $root;
+        $this->root = realpath($root);
+        return $this->root;
     }
 
     /**

--- a/tests/N98/Magento/Command/Installer/UninstallCommandTest.php
+++ b/tests/N98/Magento/Command/Installer/UninstallCommandTest.php
@@ -6,59 +6,20 @@ use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use N98\Magento\Command\PHPUnit\TestCase;
-use org\bovigo\vfs\vfsStream;
 
+/**
+ * Class UninstallCommandTest
+ * @package N98\Magento\Command\Installer
+ * @author  Aydin Hassan <aydin@hotmail.co.uk>
+ */
 class UninstallCommandTest extends TestCase
 {
-    /**
-     * @return string Get Magento Root
-     */
-    protected function getMageRoot()
-    {
-        return getenv('N98_MAGERUN_TEST_MAGENTO_ROOT');
-    }
-
-    /**
-     * @return string Get Magento local.xml file location
-     */
-    protected function getMagentoFile()
-    {
-        return getenv('N98_MAGERUN_TEST_MAGENTO_ROOT') . "/app/etc/local.xml";
-    }
-
-
-    /**
-     * Check that uninstall -f actually removes magento
-     */
-    public function testUninstallForceActuallyRemoves()
-    {
-        /*
-        $application = $this->getApplication();
-        $application->add(new UninstallCommand());
-        $command = $this->getApplication()->find('uninstall');
-
-        $commandTester = new CommandTester($command);
-
-        $commandTester->execute(
-            array(
-                'command' => $command->getName(),
-                '--force' => true
-            )
-        );
-
-        $this->assertContains("Dropped database", $commandTester->getDisplay());
-        $this->assertContains("Remove directory " . $this->getMageRoot(), $commandTester->getDisplay());
-        $this->assertContains("Done", $commandTester->getDisplay());
-        $this->assertFileNotExists($this->getMagentoFile());
-        */
-    }
 
     /**
      * Check that Magento is not removed if confirmation is denied
      */
     public function testUninstallDoesNotUninstallIfConfirmationDenied()
     {
-        /*
         $application = $this->getApplication();
         $application->add(new UninstallCommand());
         $command = $this->getApplication()->find('uninstall');
@@ -69,38 +30,39 @@ class UninstallCommandTest extends TestCase
         $dialog->setInputStream($this->getInputStream('no\n'));
         $command->setHelperSet(new HelperSet(array($dialog)));
 
-        $commandTester->execute(array('command' => $command->getName()));
+        $commandTester->execute(array(
+            'command'               => $command->getName(),
+            '--installationFolder'  => $this->getTestMagentoRoot()
+        ));
         $this->assertEquals("Really uninstall ? [n]: ", $commandTester->getDisplay());
 
         //check magento still installed
-        $this->assertFileExists($this->getMagentoFile());
-        */
+        $this->assertFileExists($this->getTestMagentoRoot() . '/app/etc/local.xml');
     }
 
     /**
-     * Check that Magento is removed if confirmation is supplied
+     * Check that uninstall -f actually removes magento
      */
-    public function testUninstallSucceedsWithConfirmation()
+    public function testUninstallForceActuallyRemoves()
     {
-        /*
         $application = $this->getApplication();
         $application->add(new UninstallCommand());
         $command = $this->getApplication()->find('uninstall');
 
         $commandTester = new CommandTester($command);
 
-        $dialog = new DialogHelper();
-        $dialog->setInputStream($this->getInputStream('yes\n'));
-        $command->setHelperSet(new HelperSet(array($dialog)));
+        $commandTester->execute(
+            array(
+                'command'               => $command->getName(),
+                '--force'               => true,
+                '--installationFolder'  => $this->getTestMagentoRoot()
+            )
+        );
 
-        $commandTester->execute(array('command' => $command->getName()));
-
-        $this->assertContains("Really uninstall ? [n]: ", $commandTester->getDisplay());
         $this->assertContains("Dropped database", $commandTester->getDisplay());
-        $this->assertContains("Remove directory " . $this->getMageRoot(), $commandTester->getDisplay());
+        $this->assertContains("Remove directory " . $this->getTestMagentoRoot(), $commandTester->getDisplay());
         $this->assertContains("Done", $commandTester->getDisplay());
-        $this->assertFileNotExists($this->getMagentoFile());
-        */
+        $this->assertFileNotExists($this->getTestMagentoRoot() . '/app/etc/local.xml');
     }
 
     /**


### PR DESCRIPTION

Currently with PHPUnit (AFAIK) there is no way to set a default test suite to run. So if a develop runs `vendor/bin/phpunit` ALL test suites will be run, and the Magento test environment will be removed. This is annoying as you cannot run the tests suite more than once. We have some options:
    
* Create a script to run tests like `runtests.php` which will just run the default test suite. (My preference)
* Update the documentation and inform to use `--testsuite` when running the tests. (I think this is a pretty annoying burden)


I'm opening this to see how it runs on travis. It *SHOULD* run the suite `n98-magerun-tests` first and then the suite `n98-magerun-magento-uninstall-tests`. I was going to separate the calls to the testsuites but I think this will affect the coverage, as the second suite will overwrite the coverage generated for the first suite. There are ways to merge coverage reports but I'm hoping we won't need to do that. In any case we shouldn't need to if the suites are ran sequentially. 

