### PR TITLE
Add error checking on sys:maintenance calls

### DIFF
--- a/src/N98/Magento/Command/System/MaintenanceCommand.php
+++ b/src/N98/Magento/Command/System/MaintenanceCommand.php
@@ -49,7 +49,9 @@ class MaintenanceCommand extends AbstractMagentoCommand
      */
     protected function _switchOn(OutputInterface $output, $flagFile)
     {
-        touch($flagFile);
+        if (!touch($flagFile)) {
+            throw new \RuntimeException('maintenance.flag file is not writable.');
+        }
         $output->writeln('Maintenance mode <info>on</info>');
     }
 
@@ -60,7 +62,9 @@ class MaintenanceCommand extends AbstractMagentoCommand
     protected function _switchOff($output, $flagFile)
     {
         if (file_exists($flagFile)) {
-            unlink($flagFile);
+            if (!unlink($flagFile)) {
+                throw new \RuntimeException('maintenance.flag file is not writable.');
+            }
         }
         $output->writeln('Maintenance mode <info>off</info>');
     }


### PR DESCRIPTION
Commands which enable and disable system maintenance check if
touch/unlink commands returned success instead of doing that blindly.