### PR TITLE
Enable mycli client for MySQL via db:console

### DIFF
--- a/src/N98/Magento/Command/Database/ConsoleCommand.php
+++ b/src/N98/Magento/Command/Database/ConsoleCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\Database;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConsoleCommand extends AbstractDatabaseCommand
@@ -12,6 +13,7 @@ class ConsoleCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:console')
             ->setAliases(array('mysql-client'))
+			->addOption('mycli', 'm', InputOption::VALUE_NONE, 'Use `mycli` as the MySQL client instead of `mysql`')
             ->setDescription('Opens mysql client by database config from local.xml')
         ;
     }
@@ -31,7 +33,8 @@ class ConsoleCommand extends AbstractDatabaseCommand
            2 => STDERR
         );
 
-        $exec = 'mysql ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
+		$mysqlClient = $input->getOption('mycli') ? 'mycli' : 'mysql';
+        $exec = $mysqlClient . ' ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
 
         $pipes = array();
         $process = proc_open($exec, $descriptorSpec, $pipes);

--- a/src/N98/Magento/Command/Database/ConsoleCommand.php
+++ b/src/N98/Magento/Command/Database/ConsoleCommand.php
@@ -13,9 +13,8 @@ class ConsoleCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:console')
             ->setAliases(array('mysql-client'))
-			->addOption('mycli', 'm', InputOption::VALUE_NONE, 'Use `mycli` as the MySQL client instead of `mysql`')
-            ->setDescription('Opens mysql client by database config from local.xml')
-        ;
+            ->addOption('mycli', 'm', InputOption::VALUE_NONE, 'Use `mycli` as the MySQL client instead of `mysql`')
+            ->setDescription('Opens mysql client by database config from local.xml');
     }
 
     /**
@@ -28,12 +27,12 @@ class ConsoleCommand extends AbstractDatabaseCommand
         $this->detectDbSettings($output);
 
         $descriptorSpec = array(
-           0 => STDIN,
-           1 => STDOUT,
-           2 => STDERR
+            0 => STDIN,
+            1 => STDOUT,
+            2 => STDERR
         );
 
-		$mysqlClient = $input->getOption('mycli') ? 'mycli' : 'mysql';
+        $mysqlClient = $input->getOption('mycli') ? 'mycli' : 'mysql';
         $exec = $mysqlClient . ' ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
 
         $pipes = array();

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -209,7 +209,7 @@ class DatabaseHelper extends AbstractHelper
             . '-u' . escapeshellarg(strval($this->dbSettings['username']))
             . ' '
             . (isset($this->dbSettings['port']) ? '-P' . escapeshellarg($this->dbSettings['port']) . ' ' : '')
-            . (!strval($this->dbSettings['password'] == '') ? '-p' . escapeshellarg($this->dbSettings['password']) . ' ' : '')
+            . (!strval($this->dbSettings['password'] == '') ? '--pass=' . escapeshellarg($this->dbSettings['password']) . ' ' : '')
             . escapeshellarg(strval($this->dbSettings['dbname']));
 
         return $string;


### PR DESCRIPTION
I made a small change to the db:console command to accept the `--mycli` or `-m` switches.  If mycli (http://mycli.net/) is installed as a binary available in your path, it will be used instead of the mysql command to connect to the MySQL server when one of the above switches is set.

Using mycli is very convenient for Magento with its auto-completion features on commands and table names.
