### PR TITLE
Enable mycli client for MySQL via db:console

### DIFF
--- a/src/N98/Magento/Command/Database/ConsoleCommand.php
+++ b/src/N98/Magento/Command/Database/ConsoleCommand.php
@@ -12,8 +12,8 @@ class ConsoleCommand extends AbstractDatabaseCommand
         $this
             ->setName('db:console')
             ->setAliases(array('mysql-client'))
-            ->setDescription('Opens mysql client by database config from local.xml')
-        ;
+            ->addOption('mycli', 'm', InputOption::VALUE_NONE, 'Use `mycli` as the MySQL client instead of `mysql`')
+            ->setDescription('Opens mysql client by database config from local.xml');
     }
 
     /**
@@ -29,10 +29,11 @@ class ConsoleCommand extends AbstractDatabaseCommand
         $descriptorSpec = array(
             0 => STDIN,
             1 => STDOUT,
-            2 => STDERR,
+            2 => STDERR
         );
 
-        $exec = 'mysql ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
+        $mysqlClient = $input->getOption('mycli') ? 'mycli' : 'mysql';
+        $exec = $mysqlClient . ' ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
 
         $pipes = array();
         $process = proc_open($exec, $descriptorSpec, $pipes);

--- a/src/N98/Util/Console/Helper/DatabaseHelper.php
+++ b/src/N98/Util/Console/Helper/DatabaseHelper.php
@@ -215,7 +215,7 @@ class DatabaseHelper extends AbstractHelper
             . '-u' . escapeshellarg(strval($this->dbSettings['username']))
             . ' '
             . (isset($this->dbSettings['port']) ? '-P' . escapeshellarg($this->dbSettings['port']) . ' ' : '')
-            . (!strval($this->dbSettings['password'] == '') ? '-p' . escapeshellarg($this->dbSettings['password']) . ' ' : '')
+            . (!strval($this->dbSettings['password'] == '') ? '--pass=' . escapeshellarg($this->dbSettings['password']) . ' ' : '')
             . escapeshellarg(strval($this->dbSettings['dbname']));
 
         return $string;


### PR DESCRIPTION
I'm creating a new pull request based on the develop branch.

This is for a small change to the db:console command to accept the --mycli or -m switches. If mycli (http://mycli.net/) is installed as a binary available in your path, it will be used instead of the mysql command to connect to the MySQL server when one of the above switches is set.

Using mycli is very convenient for Magento with its auto-completion features on commands and table names.

It makes more sense to provide an optional switch (--mycli or -m) in n98-magerun instead of creating a custom shell alias since the impact of doing the switch is much less than changing the MySQL client via an alias. The alias may have unintentional consequences with other applications that depend on the `mysql` command to be the actual `mysql` command and not an alias to `mycli`.
