### PR TITLE
Removed duplicate assignment when detecting Magento

### DIFF
--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -173,7 +173,6 @@ abstract class AbstractMagentoCommand extends Command
         $this->_magentoEnterprise = $this->getApplication()->isMagentoEnterprise();
         $this->_magentoRootFolder = $this->getApplication()->getMagentoRootFolder();
         $this->_magentoMajorVersion = $this->getApplication()->getMagentoMajorVersion();
-        $this->_magentoRootFolder = $this->getApplication()->getMagentoRootFolder();
 
         if (!$silent) {
             $editionString = ($this->_magentoEnterprise ? ' (Enterprise Edition) ' : '');


### PR DESCRIPTION
Just a small syntax error with duplicate assignment statements.