### PR TITLE
Bash autocomplete: Allow path completion

### DIFF
--- a/autocompletion/bash/bash_complete
+++ b/autocompletion/bash/bash_complete
@@ -28,7 +28,4 @@ _n98-magerun()
     return 0
 }
 
-
-complete -F _n98-magerun n98-magerun.phar
-complete -F _n98-magerun n98-magerun
-complete -F _n98-magerun magerun
+complete -o dirnames -F _n98-magerun n98-magerun.phar n98-magerun magerun


### PR DESCRIPTION
Proposed fix for #695 Bash autocomplete doesn't allow path completion

Also make a single call to complete for all 3 names instead of 3 separate calls