### PR TITLE
Include custom cache-types when cleaning cache

### DIFF
--- a/src/N98/Magento/Command/Cache/CleanCommand.php
+++ b/src/N98/Magento/Command/Cache/CleanCommand.php
@@ -45,7 +45,7 @@ HELP;
         $this->detectMagento($output, true);
         if ($this->initMagento()) {
             \Mage::app()->loadAreaPart('adminhtml', 'events');
-            $allTypes = \Mage::app()->useCache();
+            $allTypes = \Mage::app()->getCacheInstance()->getTypes();
             $typesToClean = $input->getArgument('type');
             $this->validateCacheCodes($typesToClean);
             $typeKeys = array_keys($allTypes);


### PR DESCRIPTION
Uses getTypes from cache instance to include custom cache types as well.

By default magerun uses Mag::app->useCache() in order to retrieve the cache types to clean, but this only seems to get the core cache types. Custom cache types added by user extensions are ignored. This fixes the issue.