### PR TITLE
Update MySQL Version Check to handle incomplete installations

### DIFF
--- a/src/N98/Magento/Command/System/Check/MySQL/VersionCheck.php
+++ b/src/N98/Magento/Command/System/Check/MySQL/VersionCheck.php
@@ -15,6 +15,11 @@ class VersionCheck implements SimpleCheck
     {
         $result = $results->createResult();
         $dbAdapter = \Mage::getModel('core/resource')->getConnection('core_write');
+        if (!$dbAdapter) {
+            $result->setStatus(Result::STATUS_ERROR);
+            $result->setMessage("<error>core_write Connection Resource not found.");
+            return;
+        }
 
         /**
          * Check Version


### PR DESCRIPTION
Users may want to run a check on the codebase, in that event - if SQL hasn't been setup for a Magento project, the $dbAdapter will be a boolean value (false), and the call on (now) line 26 will result in a Fatal Error.

Checking for $dbAdapter to be truthy and setting an appropriate error if it is not, and exiting the function, allows for the script to continue on unhindered.