### PR TITLE
Update MySQL Engine Check to handle incomplete installations

### DIFF
--- a/src/N98/Magento/Command/System/Check/MySQL/EnginesCheck.php
+++ b/src/N98/Magento/Command/System/Check/MySQL/EnginesCheck.php
@@ -15,6 +15,14 @@ class EnginesCheck implements SimpleCheck
     {
         $result = $results->createResult();
         $dbAdapter = \Mage::getModel('core/resource')->getConnection('core_write');
+        
+        if (!$dbAdapter instanceof \Varien_Db_Adapter_Interface) {
+            $result->setStatus(Result::STATUS_ERROR);
+            $result->setMessage(
+                "<error>Mysql Version: Can not check. Unable to obtain resource connection 'core_write'.</error>"
+            );
+            return;
+        }
 
         $engines = $dbAdapter->fetchAll('SHOW ENGINES');
         $innodbFound = false;


### PR DESCRIPTION
Users may want to run a check on the codebase, in that event - if SQL hasn't been setup for a Magento project, the $dbAdapter will be a boolean value (false), and the call on (now) line 27 will result in a Fatal Error.

Checking for $dbAdapter to be an instance of the Db_Adapter_Interface and setting an appropriate error if it is not, and exiting the function, allows for the script to continue on unhindered.