### PR TITLE
[FIX] phar compression openfiles limit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,10 +16,17 @@ if [ ! -d "build/vendor" ]; then
     ./composer.phar -d=build install
 fi
 
+ulimit -Sn $(ulimit -Hn)
 php -f build/vendor/phing/phing/bin/phing -dphar.readonly=0 -- -verbose dist
+BUILD_STATUS=$?
 
 php -f "n98-magerun.phar" -- --version
 
 ls -go --full-time n98-magerun.phar
 
 php -r 'echo "SHA1: ", sha1_file("n98-magerun.phar"), "\nMD5.: ", md5_file("n98-magerun.phar"), "\n";'
+
+if [ ${BUILD_STATUS} -ne 0 ]; then
+    >&2 echo "error: phing build failed with exit status ${BUILD_STATUS}"
+    exit ${BUILD_STATUS}
+fi


### PR DESCRIPTION
Compressing a phar file needs a lot of open file descriptors/file handles, roughly as many as compressed files it contains.

As that limit is (for magerun normally) below the hard limit (of an assumed 4096), *build.sh* raises the soft-limit to the hard-limit prior running the phing build.

- The *build.sh* script raises the openfiles soft-limit to the maximum
  possible size (the hard-limit).

- The *build.sh* script did not exit with a non-zero exit status when it
  ran into an error on build. Fix by keeping the exit status and returning
  it.

- The patched phing task to create the phar file shows the number of files
  that are compressed.

- The patched phing task catches BadMethodCallException on
  Phar::compressFiles(), checks for the exception message and inserts a
  more-saying exception message in the middle.

This should alleviate the problem reported in #714. In case the error
happens again, more information should be available from the exception
message then.