### PR TITLE
[TASK] #691 PHP 7 backward compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ matrix:
     # Lint PHP code with PHP 7.0
     - php: 7.0
       env: LINTSH=1
-      script: find {src,tests} -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
+      script: find {src,tests} -name "*.php" ! -path '*/String.php' -print0 | xargs -0 -n1 -P8 php -l
 
 before_install:
   - travis_retry composer self-update

--- a/src/N98/Util/String.php
+++ b/src/N98/Util/String.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace N98\Util;
+
+/**
+ * Class String
+ *
+ * This class is PHP 7 incompatible which is why it has been renamed to BinaryString
+ *
+ * @deprecated 1.97.6
+ *
+ * @package N98\Util
+ */
+class String extends BinaryString
+{
+}


### PR DESCRIPTION
changes in 2c4a331 are not backwards compatible so would break on minor
release.

this commit adds the String utility class again ensuring that potential
magerun extensions do not break.