### PR TITLE
Feature/720 check class exists on lookup

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1178,6 +1178,8 @@ Resolve/Lookup Class Names
 
 Resolves the given type and grouped class name to a class name, useful for debugging rewrites.
 
+If the resolved class doesn't exist, an info message will be displayed.
+
 .. code-block:: sh
 
    $ n98-magerun.phar dev:class:lookup <block|model|helper> <name>

--- a/src/N98/Magento/Command/Developer/ClassLookupCommand.php
+++ b/src/N98/Magento/Command/Developer/ClassLookupCommand.php
@@ -39,6 +39,10 @@ class ClassLookupCommand extends AbstractMagentoCommand
         if ($this->initMagento()) {
             $resolved = $this->_getConfig()->getGroupedClassName($input->getArgument('type'), $input->getArgument('name'));
             $output->writeln(ucfirst($input->getArgument('type')) . ' <comment>' . $input->getArgument('name') . "</comment> resolves to <comment>" . $resolved . '</comment>');
+            
+            if (!class_exists('\\' . $resolved)) {
+                $output->writeln('<info>Note:</info> Class <comment>' . $resolved . '</comment> does not exist!');
+            }
         }
     }
 }

--- a/tests/N98/Magento/Command/Developer/ClassLookupCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/ClassLookupCommandTest.php
@@ -7,7 +7,17 @@ use N98\Magento\Command\PHPUnit\TestCase;
 
 class ClassLookupCommandTest extends TestCase
 {
-    public function testExecute()
+    /**
+     * Test that the class lookup command resolves to the expected Magento class, and optionally
+     * whether it outputs a notice informing that the class doesn't exist
+     * @dataProvider classLookupProvider
+     *
+     * @param string $type     Model, helper, block
+     * @param string $name     Magento dev code
+     * @param string $expected Resolved class name
+     * @param bool   $exists   Whether the resolved class should exist
+     */
+    public function testExecute($type, $name, $expected, $exists)
     {
         $application = $this->getApplication();
         $application->add(new ClassLookupCommand());
@@ -17,11 +27,61 @@ class ClassLookupCommandTest extends TestCase
         $commandTester->execute(
             array(
                 'command' => $command->getName(),
-                'type'    => 'model',
-                'name'    => 'catalog/product',
+                'type'    => $type,
+                'name'    => $name
             )
         );
     
-        $this->assertRegExp('/Mage_Catalog_Model_Product/', $commandTester->getDisplay());
+        $output = $commandTester->getDisplay();
+        $this->assertRegExp(sprintf('/%s/', $expected), $output);
+
+        $existsAssertion = (!$exists) ? 'assertRegExp' : 'assertNotRegExp';
+        $this->{$existsAssertion}(sprintf('/%s/', 'does not exist'), $output);
+    }
+
+    /**
+     * Provide data for the class lookup testExecute()
+     * @return array
+     */
+    public function classLookupProvider()
+    {
+        return array(
+            array(
+                'type'     => 'model',
+                'name'     => 'catalog/product',
+                'expected' => 'Mage_Catalog_Model_Product',
+                'exists'   => true
+            ),
+            array(
+                'type'     => 'model',
+                'name'     => 'catalog/nothing_to_see_here',
+                'expected' => 'Mage_Catalog_Model_Nothing_To_See_Here',
+                'exists'   => false
+            ),
+            array(
+                'type'     => 'helper',
+                'name'     => 'checkout/cart',
+                'expected' => 'Mage_Checkout_Helper_Cart',
+                'exists'   => true
+            ),
+            array(
+                'type'     => 'helper',
+                'name'     => 'checkout/stolen_creditcards',
+                'expected' => 'Mage_Checkout_Helper_Stolen_Creditcards',
+                'exists'   => false
+            ),
+            array(
+                'type'     => 'block',
+                'name'     => 'customer/account_dashboard',
+                'expected' => 'Mage_Customer_Block_Account_Dashboard',
+                'exists'   => true
+            ),
+            array(
+                'type'     => 'block',
+                'name'     => 'customer/my_code_snippets',
+                'expected' => 'Mage_Customer_Block_My_Code_Snippets',
+                'exists'   => false
+            )
+        );
     }
 }


### PR DESCRIPTION
Add info message to `dev:class:lookup` output when the resolved class doesn't exist.

References issue #720 .