### PR TITLE
[#727] Merge DB cron expressions from the database into the XML

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -13,7 +13,18 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
     {
         $table = array();
 
-        foreach (\Mage::getConfig()->getNode('crontab/jobs')->children() as $job) {
+        // Get job configuration from XML and database. Expression priority is given to the database.
+        $config = \Mage::getConfig();
+
+        $xmlJobConfig = $config->getNode('crontab/jobs');
+        $dbJobConfig  = $config->getNode('default/crontab/jobs');
+
+        $xmlJobs      = ($xmlJobConfig) ? $xmlJobConfig->children() : array();
+        $databaseJobs = ($dbJobConfig) ? $dbJobConfig->children() : array();
+
+        $jobs = array_merge((array)$xmlJobs, (array)$databaseJobs);
+
+        foreach ($jobs as $job) {
             /* @var $job \Mage_Core_Model_Config_Element */
             $table[] = array('Job'  => (string) $job->getName()) + $this->getSchedule($job);
         }


### PR DESCRIPTION
This pull request addresses issue #727 where cron expressions in the `core_config_data` table were not being displayed when running `sys:cron:list`.

In accordance with the [Magento core cron model](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Cron/Model/Observer.php#L86-L98), we should load both and merge them together.

Matching core functionality, the database entries take priority over XML entries.