### PR TITLE
[FIX] #741 remove customer exec dependency

### DIFF
--- a/src/N98/Magento/Command/Customer/AbstractCustomerCommand.php
+++ b/src/N98/Magento/Command/Customer/AbstractCustomerCommand.php
@@ -56,13 +56,4 @@ abstract class AbstractCustomerCommand extends AbstractMagentoCommand
     {
         return $this->_getResourceModel('directory/country_collection', 'Mage_Directory_Model_Resource_Country_Collection');
     }
-
-
-    /**
-     * @return bool
-     */
-    public function isEnabled()
-    {
-        return Exec::allowed();
-    }
 }

--- a/src/N98/Magento/Command/Database/ImportCommand.php
+++ b/src/N98/Magento/Command/Database/ImportCommand.php
@@ -34,6 +34,14 @@ HELP;
     }
 
     /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return Exec::allowed();
+    }
+
+    /**
      * Optimize a dump by converting single INSERTs per line to INSERTs with multiple lines
      * @param $fileName
      * @return string temporary filename

--- a/src/N98/Magento/Command/Database/QueryCommand.php
+++ b/src/N98/Magento/Command/Database/QueryCommand.php
@@ -33,6 +33,14 @@ HELP;
     }
 
     /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return Exec::allowed();
+    }
+
+    /**
      * Returns the query string with escaped ' characters so it can be used
      * within the mysql -e argument.
      *

--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -113,6 +113,14 @@ HELP;
     }
 
     /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return Exec::allowed();
+    }
+
+    /**
      * @param InputInterface $input
      * @param OutputInterface $output
      * @throws RuntimeException

--- a/src/N98/Magento/Command/OpenBrowserCommand.php
+++ b/src/N98/Magento/Command/OpenBrowserCommand.php
@@ -22,6 +22,14 @@ class OpenBrowserCommand extends AbstractMagentoCommand
     }
 
     /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return Exec::allowed();
+    }
+
+    /**
      * @param InputInterface $input
      * @param OutputInterface $output
      * @throws RuntimeException

--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -5,6 +5,7 @@ namespace N98\Magento\Command;
 use InvalidArgumentException;
 use N98\Magento\Command\AbstractMagentoCommand;
 use N98\Util\BinaryString;
+use N98\Util\Exec;
 use RuntimeException;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Input\InputArgument;
@@ -103,6 +104,14 @@ Example:
 It's possible to define multiple values by passing more than one option.
 HELP;
         $this->setHelp($help);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return Exec::allowed();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -22,18 +22,23 @@ class Exec {
 
     /**
      * @param string $command
-     * @param string $commandOutput
+     * @param string $output
      * @param int $returnCode
      */
-    public static function run($command, &$commandOutput = null, &$returnCode = null) {
+    public static function run($command, &$output = null, &$returnCode = null) {
+
+        if (!self::allowed()) {
+            $message = sprintf("No PHP exec(), can not execute command '%s'.", $command);
+            throw new RuntimeException($message);
+        }
 
         $command = $command . self::REDIRECT_STDERR_TO_STDOUT;
 
-        exec($command, $commandOutput, $returnCode);
-        $commandOutput = self::parseCommandOutput($commandOutput);
+        exec($command, $outputArray, $returnCode);
+        $output = self::parseCommandOutput($outputArray);
 
         if ($returnCode !== self::CODE_CLEAN_EXIT) {
-            throw new RuntimeException($commandOutput);
+            throw new RuntimeException($output);
         }
     }
 
@@ -48,11 +53,13 @@ class Exec {
     }
 
     /**
-     * @param $commandOutput
+     * string from array of strings representing one line per entry
+     *
+     * @param array $commandOutput
      * @return string
      */
-    private static function parseCommandOutput($commandOutput) {
+    private static function parseCommandOutput(array $commandOutput) {
 
-        return implode(PHP_EOL, $commandOutput);
+        return implode(PHP_EOL, $commandOutput) . PHP_EOL;
     }
 }


### PR DESCRIPTION
remove isEnabled() check from the abstract customer command.

by it the abstract customer command was checking for the exec() function
but all of the customer commands do not need it.

the flaw cam to light in issue #741.

the check has been introduced in error in 5555a78 .

the fix is to remove the check and to re-add it in the correct places:

- Database\ImportCommand
- Database\QueryCommand
- Installer\InstallCommand
- OpenBrowserCommand
- ScriptCommand

As the check was originally with some other commands, in Exec the
allowance-check hast been additionally added into Exec::run() to give a
more saying message in a RuntimeException instead of a fatal error.