### PR TITLE
[FIX] Install command fails if usting custom PHP version

### DIFF
--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -731,11 +731,10 @@ HELP;
 
         $output->writeln('<info>Start installation process.</info>');
 
-        if (OperatingSystem::isWindows()) {
-            $installCommand = 'php -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
-        } else {
-            $installCommand = '/usr/bin/env php -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
-        }
+        $phpExec = $this->getPhpExecutable();
+        $installCommand = $phpExec . ' -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
+
+
         $output->writeln('<comment>' . $installCommand . '</comment>');
         Exec::run($installCommand, $installationOutput, $returnStatus);
         if ($returnStatus !== self::EXEC_STATUS_OK) {
@@ -840,6 +839,26 @@ HELP;
             $output->writeln('<error>' . $e->getMessage() . '</error>');
         }
     }
+
+
+    /**
+     * Retrieve path to php executable
+     *
+     * @return string
+     */
+    protected function getPhpExecutable()
+    {
+        $php = getenv('_');
+        if(!$php) {
+            if (OperatingSystem::isWindows()) {
+                $php = 'php';
+            } else {
+                $php = '/usr/bin/env php';
+            }
+        }
+        return $php;
+    }
+
 
     /**
      * @return array


### PR DESCRIPTION
Using a custom PHP version, install command fails as it uses the default OS version.
Works fine on OSX, not sure about Win