### PR TITLE
[FIX] PHP7 Uncaught TypeError in sys:setup:incremental

### DIFF
--- a/src/N98/Magento/Command/System/Setup/IncrementalCommand.php
+++ b/src/N98/Magento/Command/System/Setup/IncrementalCommand.php
@@ -168,16 +168,16 @@ class IncrementalCommand extends AbstractMagentoCommand
     }
 
     /**
-     * @param ReflectionMethod $method
-     * @param Object            $object
-     * @param array             $args
+     * @param string $method
+     * @param Object $object
+     * @param array  $args
      *
      * @return mixed
      */
-    protected function _callProtectedMethodFromObject(ReflectionMethod $method, $object, $args = array())
+    protected function _callProtectedMethodFromObject($method, $object, $args = array())
     {
         $r = new ReflectionClass($object);
-        $m = $r->getMethod('_getAvailableDbFiles');
+        $m = $r->getMethod($method);
         $m->setAccessible(true);
         return $m->invokeArgs($object, $args);
     }


### PR DESCRIPTION
## System info
 - n98-magerun 1.97.8
 - PHP 7.0.1
 - Magento CE 1.9.2.2

## Problem description

When running the `sys:setup:incremental` subcommand, n98-magerun crashes with the following output:

```bash
$ n98-magerun sys:setup:incremental

                                    
  Analyzing Setup Resource Classes  
                                    

Found 82 configured setup resource(s)
Found 3 setup resource(s) which need an update
Press Enter to View Update Information: 

                               
  Detailed Update Information  
                               

+--------------------------------------------------+

<snip>

Structure Files to Run: 
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to N98\Magento\Command\System\Setup\IncrementalCommand::_callProtectedMethodFromObject() must be an instance of ReflectionMethod, string given, called in phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php on line 134 and defined in phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php:177
Stack trace:
#0 phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php(134): N98\Magento\Command\System\Setup\IncrementalCommand->_callProtectedMethodFromObject('_getAvailableDb...', Object(Mage_Core_Model_Resource_Setup), Array)
#1 phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php(325): N98\Magento\Command\System\Setup\IncrementalCommand->_getAvaiableDbFilesFromResource(Object(Mage_Core_Model_Resource_Setup), Array)
#2 phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php(592): N98\Ma in phar:///usr/local/bin/n98-magerun/src/N98/Magento/Command/System/Setup/IncrementalCommand.php on line 177
```

## Fix
After adjusting the docblock/type hint, the program successfully runs all setup resource scripts.