### PR TITLE
Return non-zero status when module rewrite conflict is positive

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
@@ -73,6 +73,7 @@ HELP;
                             $conflictCounter == 1 ? 'conflict was' : 'conflicts were'
                         );
                         $output->writeln('<error>' . $message . '</error>');
+                        return 1;
                     } else {
                         $output->writeln('<info>No rewrite conflicts were found.</info>');
                     }

--- a/tests/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommandTest.php
@@ -35,12 +35,13 @@ class ConflictsCommandTest extends TestCase
          * Junit Log without any output
          */
         $commandTester = new CommandTester($command);
-        $commandTester->execute(
+        $result = $commandTester->execute(
             array(
                 'command'     => $command->getName(),
                 '--log-junit' => '_output.xml',
             )
         );
+        $this->assertEquals(0, $result);
         $this->assertEquals('', $commandTester->getDisplay());
         $this->assertFileExists('_output.xml');
         @unlink('_output.xml');
@@ -61,7 +62,8 @@ class ConflictsCommandTest extends TestCase
         );
         $command = $this->getCommandWithMockLoadRewrites($rewrites);
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName()));
+        $result = $commandTester->execute(array('command' => $command->getName()));
+        $this->assertNotEquals(0, $result);
         $this->assertContains('1 conflict was found', $commandTester->getDisplay());
     }
 
@@ -82,7 +84,8 @@ class ConflictsCommandTest extends TestCase
         );
         $command = $this->getCommandWithMockLoadRewrites($rewrites);
         $commandTester = new CommandTester($command);
-        $commandTester->execute(array('command' => $command->getName()));
+        $result = $commandTester->execute(array('command' => $command->getName()));
+        $this->assertEquals(0, $result);
         $this->assertContains('No rewrite conflicts were found', $commandTester->getDisplay());
     }
 


### PR DESCRIPTION
This makes the `dev:module:rewrite:conflicts` command return a non-zero exit code if a rewrite conflict is detected.  This is useful for integration testing, so that a build will be marked as failed when a conflict is introduced.