### PR TITLE
[FIX] install cmd fails using custom php binary

### DIFF
--- a/src/N98/Magento/Command/Installer/InstallCommand.php
+++ b/src/N98/Magento/Command/Installer/InstallCommand.php
@@ -739,11 +739,10 @@ HELP;
 
         $output->writeln('<info>Start installation process.</info>');
 
-        if (OperatingSystem::isWindows()) {
-            $installCommand = 'php -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
-        } else {
-            $installCommand = '/usr/bin/env php -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
-        }
+        $phpExec = OperatingSystem::getPhpBinary();
+        $installCommand = $phpExec . ' -f ' . escapeshellarg($this->getInstallScriptPath()) . ' -- ' . $installArgs;
+
+
         $output->writeln('<comment>' . $installCommand . '</comment>');
         Exec::run($installCommand, $installationOutput, $returnStatus);
         if ($returnStatus !== self::EXEC_STATUS_OK) {

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -121,7 +121,7 @@ class OperatingSystem
      */
     public static function getPhpBinary()
     {
-        // PHP_BINARY (> php 5.4)
+        // PHP_BINARY (>= php 5.4)
         if (defined('PHP_BINARY')) {
             return PHP_BINARY;
         }

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -113,4 +113,21 @@ class OperatingSystem
     {
         return getcwd();
     }
+
+    /**
+     * Retrieve path to php binary
+     *
+     * @return string
+     */
+    public static function getPhpBinary()
+    {
+        // PHP_BINARY (> php 5.4)
+        if (defined('PHP_BINARY')) {
+            return PHP_BINARY;
+        }
+        if (self::isWindows()) {
+            return 'php';
+        }
+        return '/usr/bin/env php';
+    }
 }

--- a/tests/N98/Util/OperatingSystemTest.php
+++ b/tests/N98/Util/OperatingSystemTest.php
@@ -79,4 +79,13 @@ class OperatingSystemTest extends \PHPUnit_Framework_TestCase
         $expected = getcwd();
         $this->assertEquals($expected, OperatingSystem::getCwd());
     }
+
+    /**
+     * @test
+     * @requires PHP 5.4
+     */
+    public function phpBinary()
+    {
+        $this->assertEquals(PHP_BINARY, OperatingSystem::getPhpBinary());
+    }
 }

--- a/tests/N98/Util/OperatingSystemTest.php
+++ b/tests/N98/Util/OperatingSystemTest.php
@@ -42,7 +42,7 @@ class OperatingSystemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @requires OS Win
+     * @requires OS ^Win
      */
     public function testIsWindows() {
         $this->assertTrue(OperatingSystem::isWindows());


### PR DESCRIPTION
Use PHP_BINARY constant if available to run the magento install command using the same PHP binary as magerun.
Also fix minor issue for running phpunit on osx/darwin