### PR TITLE
Adding a prompt when unlocking all admin users.

### DIFF
--- a/src/N98/Magento/Command/Admin/User/UnlockCommand.php
+++ b/src/N98/Magento/Command/Admin/User/UnlockCommand.php
@@ -49,12 +49,15 @@ class UnlockCommand extends AbstractAdminUserCommand
                 $output->writeln('<info><comment>' . $username . '</comment> unlocked</info>');
                 return;
             }
-            \Mage::getResourceModel('enterprise_pci/admin_user')->unlock(
-                \Mage::getModel('admin/user')
-                    ->getCollection()
-                    ->getAllIds()
-            );
-            $output->writeln('<info><comment>All admins</comment> unlocked</info>');
+            $dialog = $this->getHelperSet()->get('dialog');
+            $shouldUnlockAll = $dialog->askConfirmation($output, '<question>Really unlock all users?</question> <comment>[n]</comment>: ', false);
+            if ($shouldUnlockAll) {
+                $ids = \Mage::getModel('admin/user')->getCollection()->getAllIds();
+                if (count($ids) > 0) {
+                    \Mage::getResourceModel('enterprise_pci/admin_user')->unlock($ids);
+                }
+                $output->writeln('<info><comment>All admins</comment> unlocked</info>');
+            }
         }
     }
 }

--- a/tests/N98/Magento/Command/Admin/User/UnlockUserCommandTest.php
+++ b/tests/N98/Magento/Command/Admin/User/UnlockUserCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace N98\Magento\Command\Admin\User;
+
+use N98\Magento\Command\PHPUnit\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ *  * Class UnlockUserCommandTest
+ *   */
+class UnlockUserCommandTest extends TestCase
+{
+
+    private function getCommand()
+    {
+        $command = new UnlockCommand();
+        $command->setApplication($this->getApplication());
+        if (!$command->isEnabled()) {
+            $this->markTestSkipped('UnlockCommand is not enabled.');
+
+        }
+        return $command;
+    }
+
+
+    public function testUnlockAllUsersPromptNo()
+    {
+        $dialog = $this->getMock('Symfony\Component\Console\Helper\DialogHelper', array('ask'));
+
+        $dialog->expects($this->once())
+            ->method('ask')
+            ->will($this->returnValue("n"));
+
+        $application = $this->getApplication();
+        $application->add($this->getCommand());
+        $command = $this->getApplication()->find('admin:user:unlock');
+        $command->getHelperSet()->set($dialog, 'dialog');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+
+        $this->assertNotContains('All admins unlocked', $commandTester->getDisplay());
+    }
+
+    public function testUnlockAllUsersPromptYes()
+    {
+        $dialog = $this->getMock('Symfony\Component\Console\Helper\DialogHelper', array('ask'));
+
+        $dialog->expects($this->once())
+            ->method('ask')
+            ->will($this->returnValue("y"));
+
+        $application = $this->getApplication();
+        $application->add($this->getCommand());
+        $command = $this->getApplication()->find('admin:user:unlock');
+        $command->getHelperSet()->set($dialog, 'dialog');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+
+        $this->assertContains('All admins unlocked', $commandTester->getDisplay());
+    }
+}
+


### PR DESCRIPTION
There have been numerous time that I run this command, expecting a prompt for a username to be entered, and it simply unlocks all users. I have added a prompt to make sure that the intention is to unlock everyone.