### PR TITLE
Added 'docroot' as a subfolder (when detecting the Magento installation)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ detect:
     - webroot
     - web-root
     - wwwroot
+    - docroot
 
 event:
   subscriber:


### PR DESCRIPTION
Many installations use `docroot` term to specify the Magento/webapplication installation directory.

I.e.: http://devdocs.magento.com/guides/v2.0/install-gde/basics/basics_docroot.html (I know Magento 2 uses `pub`, but docroot is a popular term - same in Drupal world.