### PR TITLE
[FIX] sed: RE error: illegal byte sequence on myqldump

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -304,7 +304,7 @@ HELP;
      */
     protected function postDumpPipeCommands()
     {
-        return ' | sed -e ' . escapeshellarg('s/DEFINER[ ]*=[ ]*[^*]*\*/\*/');
+        return ' | LANG=C LC_CTYPE=C LC_ALL=C sed -e ' . escapeshellarg('s/DEFINER[ ]*=[ ]*[^*]*\*/\*/');
     }
 
     /**


### PR DESCRIPTION
Prepend LANG=C LC_CTYPE=C LC_ALL=C to sed command

issue: #771 