### PR TITLE
Refactor mysqldump command order

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -229,9 +229,11 @@ HELP;
             $ignore .= '--ignore-table=' . $this->dbSettings['dbname'] . '.' . $tableName . ' ';
         }
 
+        $mysqlClientToolConnectionString = $this->getHelper('database')->getMysqlClientToolConnectionString();
+
         if (count($stripTables) > 0) {
             // dump structure for strip-tables
-            $exec = 'mysqldump ' . $dumpOptions . '--no-data ' . $this->getHelper('database')->getMysqlClientToolConnectionString();
+            $exec = 'mysqldump ' . $dumpOptions . '--no-data ' . $mysqlClientToolConnectionString;
             $exec .= ' ' . implode(' ', $stripTables);
             $exec .= $this->postDumpPipeCommands();
             $exec = $compressor->getCompressingCommand($exec);
@@ -242,7 +244,7 @@ HELP;
         }
 
         // dump data for all other tables
-        $exec = 'mysqldump ' . $dumpOptions . $ignore . $this->getHelper('database')->getMysqlClientToolConnectionString();
+        $exec = 'mysqldump ' . $dumpOptions . $mysqlClientToolConnectionString . ' ' . $ignore;
         $exec .= $this->postDumpPipeCommands();
         $exec = $compressor->getCompressingCommand($exec);
         if (!$input->getOption('stdout')) {


### PR DESCRIPTION
The intention of this is to make it easier to grok when looking at both generated commands.

With this modification it will generate commands like:
```
mysqldump --single-transaction --quick --routines --no-data -h'127.0.0.1'
mysqldump --single-transaction --quick --routines -h'127.0.0.1 --all-ignores-go-here'
```

When you have hundreds of tables to be ignored, quickly grokking the table being dumped can be annoying with the current implementation as you have to view/modify the very beginning of the first line with the very end of the second line.