### PR TITLE
Add errors-only filter to sys:setup:compare-version

### DIFF
--- a/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
+++ b/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
@@ -53,6 +53,8 @@ HELP;
                 unset($headers[array_search('Data', $headers)]);
             }
 
+            $hasStatusErrors = false;
+
             $errorCounter = 0;
             $table = array();
             foreach ($setups as $setupName => $setup) {
@@ -80,6 +82,11 @@ HELP;
                     $row['Data-Version'] = $dataVersion;
                 }
                 $row['Status'] = $ok ? 'OK' : 'Error';
+
+                if (!$ok) {
+                    $hasStatusErrors = true;
+                }
+
                 $table[] = $row;
             }
 
@@ -141,6 +148,13 @@ HELP;
                         $this->writeSection($output, 'No setup problems were found.', 'info');
                     }
                 }
+            }
+
+            if ($hasStatusErrors) {
+                //Return a non-zero status to indicate there is an error in the setup scripts.
+                return 1;
+            } else {
+                return 0;
             }
         }
     }

--- a/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
+++ b/src/N98/Magento/Command/System/Setup/CompareVersionsCommand.php
@@ -18,6 +18,7 @@ class CompareVersionsCommand extends AbstractMagentoCommand
             ->setName('sys:setup:compare-versions')
             ->addOption('ignore-data', null, InputOption::VALUE_NONE, 'Ignore data updates')
             ->addOption('log-junit', null, InputOption::VALUE_REQUIRED, 'Log output to a JUnit xml file.')
+            ->addOption('errors-only', null, InputOption::VALUE_NONE, 'Only display Setup resources where Status equals Error.')
             ->addOption(
                 'format',
                 null,
@@ -80,6 +81,12 @@ HELP;
                 }
                 $row['Status'] = $ok ? 'OK' : 'Error';
                 $table[] = $row;
+            }
+
+            if ($input->getOption('errors-only')) {
+                $table = array_filter($table, function($row){
+                    return ($row['Status'] === 'Error');
+                });
             }
 
             //if there is no output format


### PR DESCRIPTION
#### Currently

The current mechanism forces all the errored setup resources to the bottom of the table.

```
magerun sys:setup:compare-versions
```
```
+-----------------------+----------------+----------------+----------------+--------+
| Setup                 | Module         | DB             | Data           | Status |
+-----------------------+----------------+----------------+----------------+--------+
| admin_setup           | 1.6.1.2        | 1.6.1.2        | 1.6.1.2        | OK     |
| bronto_common_setup   | 2.4.4          | 2.4.2.2        | 2.4.2.2        | Error  |
+-----------------------+----------------+----------------+----------------+--------+
```
#### Proposed

The proposed update is to add an `--errors-only` option, that will filter out all the rows with Status = "OK".

```
magerun sys:setup:compare-versions  --errors-only
```
```
+-----------------------+----------------+----------------+----------------+--------+
| Setup                 | Module         | DB             | Data           | Status |
+-----------------------+----------------+----------------+----------------+--------+
| bronto_common_setup   | 2.4.4          | 2.4.2.2        | 2.4.2.2        | Error  |
+-----------------------+----------------+----------------+----------------+--------+
```

#### Reasoning

`sys:setup:compare-versions` is a useful tool to hook into a deployment. But listing the full module resource list every time seems overkill and makes the logs look nasty. It'd be nice to streamline it to just report errors.