### PR TITLE
Adding a prompt when unlocking all admin users.

### DIFF
--- a/src/N98/Magento/Command/Admin/User/LockdownCommand.php
+++ b/src/N98/Magento/Command/Admin/User/LockdownCommand.php
@@ -55,13 +55,13 @@ HELP
 
         /** @var $dialog \Symfony\Component\Console\Helper\DialogHelper */
         $dialog = $this->getHelperSet()->get('dialog');
-        $confirm = $dialog->ask(
+        $confirm = $dialog->askConfirmation(
             $output,
-            '<info><comment>Are you sure? This will lock all admin accounts! Type "yes" to continue...</comment></info>'
-            . PHP_EOL
+            sprintf('<question>Really lock all %d admin users?</question> <comment>[n]</comment>: ', count($userIds)),
+            false
         );
 
-        if ('yes' !== $confirm) {
+        if (!$confirm) {
             return;
         }
 

--- a/tests/N98/Magento/Command/Admin/User/UnlockUserCommandTest.php
+++ b/tests/N98/Magento/Command/Admin/User/UnlockUserCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace N98\Magento\Command\Admin\User;
+
+use N98\Magento\Command\PHPUnit\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ *  * Class UnlockUserCommandTest
+ *   */
+class UnlockUserCommandTest extends TestCase
+{
+
+    private function getCommand()
+    {
+        $command = new UnlockCommand();
+        $command->setApplication($this->getApplication());
+        if (!$command->isEnabled()) {
+            $this->markTestSkipped('UnlockCommand is not enabled.');
+
+        }
+        return $command;
+    }
+
+
+    public function testUnlockAllUsersPromptNo()
+    {
+        $dialog = $this->getMock('Symfony\Component\Console\Helper\DialogHelper', array('ask'));
+
+        $dialog->expects($this->once())
+            ->method('ask')
+            ->will($this->returnValue("n"));
+
+        $application = $this->getApplication();
+        $application->add($this->getCommand());
+        $command = $this->getApplication()->find('admin:user:unlock');
+        $command->getHelperSet()->set($dialog, 'dialog');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+
+        $this->assertNotContains('All admins unlocked', $commandTester->getDisplay());
+    }
+
+    public function testUnlockAllUsersPromptYes()
+    {
+        $dialog = $this->getMock('Symfony\Component\Console\Helper\DialogHelper', array('ask'));
+
+        $dialog->expects($this->once())
+            ->method('ask')
+            ->will($this->returnValue("y"));
+
+        $application = $this->getApplication();
+        $application->add($this->getCommand());
+        $command = $this->getApplication()->find('admin:user:unlock');
+        $command->getHelperSet()->set($dialog, 'dialog');
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command' => $command->getName()));
+
+        $this->assertContains('All admins unlocked', $commandTester->getDisplay());
+    }
+}
+


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes pull request #762 

Changes proposed in this pull request:

- Merge conflicts resolved with #810 changes
- Compatibility changes made between LockdownCommand and UnlockCommand for consistency
- Messages adjusted slightly in UnlockCommand messages from original command