### PR TITLE
include default website/store in config:delete

### DIFF
--- a/src/N98/Magento/Command/Config/DeleteCommand.php
+++ b/src/N98/Magento/Command/Config/DeleteCommand.php
@@ -86,12 +86,12 @@ HELP;
             $deleted[] = $this->deleteConfigEntry($path, 'default', 0);
 
             // Delete websites
-            foreach (\Mage::app()->getWebsites() as $website) {
+            foreach (\Mage::app()->getWebsites(true) as $website) {
                 $deleted[] = $this->deleteConfigEntry($path, 'websites', $website->getId());
             }
 
             // Delete stores
-            foreach (\Mage::app()->getStores() as $store) {
+            foreach (\Mage::app()->getStores(true) as $store) {
                 $deleted[] = $this->deleteConfigEntry($path, 'stores', $store->getId());
             }
         } else {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)  
~~- [] README.md reflects changes (if any)~~ **N/A**

Subject: include default website/store in config:delete

Changes proposed in this pull request:

Per README `config:delete --all` _"Deletes all entries of a path (ignores --scope and --scope-id)"_

As implemented `config:delete --all` enumerates `Mage::app()->getWebsites()` and `Mage::app()->getStores()`.

With no parameters passed the default website and store is excluded from the respective `Mage::app()->getWebsites()` and `Mage::app()->getStores()` functions.

Per https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Core/Model/App.php#L984-L1002 and https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Core/Model/App.php#L891-L914