### PR TITLE
Add config:delete --force option

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -628,7 +628,7 @@ Delete Config
 
 .. code-block:: sh
 
-   $ n98-magerun.phar config:delete [--scope[="..."]] [--scope-id[="..."]] [--all] path
+   $ n98-magerun.phar config:delete [--scope[="..."]] [--scope-id[="..."]] [--all] [--force] path
 
 Arguments:
     path        The config path
@@ -637,6 +637,7 @@ Options:
     --scope     The config scope (default, websites, stores)
     --scope-id  The config value's scope ID
     --all       Deletes all entries of a path (ignores --scope and --scope-id)
+    --force     Allow deletion of non-standard scope-id's for websites and stores
 
 Config Search
 """""""""""""

--- a/readme.rst
+++ b/readme.rst
@@ -585,7 +585,7 @@ Set Config
 
 .. code-block:: sh
 
-   $ n98-magerun.phar config:set [--scope[="..."]] [--scope-id[="..."]] [--encrypt] path value
+   $ n98-magerun.phar config:set [--scope[="..."]] [--scope-id[="..."]] [--encrypt] [--force] path value
 
 Arguments:
     path        The config path
@@ -595,6 +595,7 @@ Options:
     --scope     The config value's scope (default: "default" | Can be "default", "websites", "stores")
     --scope-id  The config value's scope ID (default: "0")
     --encrypt   Encrypt the config value using local.xml's crypt key
+    --force     Allow creation of non-standard scope-id's for websites and stores
 
 Get Config
 """"""""""

--- a/src/N98/Magento/Command/Config/AbstractConfigCommand.php
+++ b/src/N98/Magento/Command/Config/AbstractConfigCommand.php
@@ -71,10 +71,11 @@ abstract class AbstractConfigCommand extends AbstractMagentoCommand
     /**
      * @param string $scope
      * @param string $scopeId
+     * @param boolean $allowZeroScope
      *
      * @return string non-negative integer number
      */
-    protected function _convertScopeIdParam($scope, $scopeId)
+    protected function _convertScopeIdParam($scope, $scopeId, $allowZeroScope=false)
     {
         if ($scope === 'default') {
             if ("$scopeId" !== "0") {
@@ -114,10 +115,12 @@ abstract class AbstractConfigCommand extends AbstractMagentoCommand
             );
         }
 
-        if (0 >= (int)$scopeId) {
-            throw new InvalidArgumentException(
-                sprintf("Invalid scope parameter, %s is not a positive integer value", var_export($scopeId, true))
-            );
+        if (!$allowZeroScope) {
+            if (0 >= (int)$scopeId) {
+                throw new InvalidArgumentException(
+                    sprintf("Invalid scope parameter, %s is not a positive integer value", var_export($scopeId, true))
+                );
+            }
         }
 
         return $scopeId;

--- a/src/N98/Magento/Command/Config/AbstractConfigCommand.php
+++ b/src/N98/Magento/Command/Config/AbstractConfigCommand.php
@@ -115,12 +115,10 @@ abstract class AbstractConfigCommand extends AbstractMagentoCommand
             );
         }
 
-        if (!$allowZeroScope) {
-            if (0 >= (int)$scopeId) {
-                throw new InvalidArgumentException(
-                    sprintf("Invalid scope parameter, %s is not a positive integer value", var_export($scopeId, true))
-                );
-            }
+        if (0 - (bool)$allowZeroScope >= (int)$scopeId) {
+            throw new InvalidArgumentException(
+                sprintf("Invalid scope parameter, %s is not a positive integer value", var_export($scopeId, true))
+            );
         }
 
         return $scopeId;

--- a/src/N98/Magento/Command/Config/DeleteCommand.php
+++ b/src/N98/Magento/Command/Config/DeleteCommand.php
@@ -23,6 +23,7 @@ class DeleteCommand extends AbstractConfigCommand
                 'default'
             )
             ->addOption('scope-id', null, InputOption::VALUE_OPTIONAL, 'The config value\'s scope ID', '0')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Allow deletion of non-standard scope-id\'s for websites and stores')
             ->addOption('all', null, InputOption::VALUE_NONE, 'Delete all entries by path')
         ;
 
@@ -48,8 +49,10 @@ HELP;
 
         $deleted = array();
 
+        $allowZeroScope = $input->getOption('force');
+
         $scope = $this->_validateScopeParam($input->getOption('scope'));
-        $scopeId = $this->_convertScopeIdParam($scope, $input->getOption('scope-id'));
+        $scopeId = $this->_convertScopeIdParam($scope, $input->getOption('scope-id'), $allowZeroScope);
 
         $path = $input->getArgument('path');
 

--- a/src/N98/Magento/Command/Config/DeleteCommand.php
+++ b/src/N98/Magento/Command/Config/DeleteCommand.php
@@ -84,17 +84,18 @@ HELP;
     protected function _deletePath(InputInterface $input, $path, $scopeId)
     {
         $deleted = array();
+        $force = $input->getOption('force');
         if ($input->getOption('all')) {
             // Default
             $deleted[] = $this->deleteConfigEntry($path, 'default', 0);
 
             // Delete websites
-            foreach (\Mage::app()->getWebsites() as $website) {
+            foreach (\Mage::app()->getWebsites($force) as $website) {
                 $deleted[] = $this->deleteConfigEntry($path, 'websites', $website->getId());
             }
 
             // Delete stores
-            foreach (\Mage::app()->getStores() as $store) {
+            foreach (\Mage::app()->getStores($force) as $store) {
                 $deleted[] = $this->deleteConfigEntry($path, 'stores', $store->getId());
             }
         } else {

--- a/src/N98/Magento/Command/Config/SetCommand.php
+++ b/src/N98/Magento/Command/Config/SetCommand.php
@@ -30,6 +30,7 @@ class SetCommand extends AbstractConfigCommand
                 InputOption::VALUE_NONE,
                 'The config value should be encrypted using local.xml\'s crypt key'
             )
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Allow creation of non-standard scope-id\'s for websites and stores')
         ;
 
         $help = <<<HELP
@@ -59,8 +60,10 @@ HELP;
             return;
         }
 
+        $allowZeroScope = $input->getOption('force');
+
         $this->_validateScopeParam($input->getOption('scope'));
-        $scopeId = $this->_convertScopeIdParam($input->getOption('scope'), $input->getOption('scope-id'));
+        $scopeId = $this->_convertScopeIdParam($input->getOption('scope'), $input->getOption('scope-id'), $allowZeroScope);
 
         $value = str_replace(array('\n', '\r'), array("\n", "\r"), $input->getArgument('value'));
         $value = $this->_formatValue($value, ($input->getOption('encrypt') ? 'encrypt' : false));


### PR DESCRIPTION
Subject: Add config:delete --force option

Fixes #811 #814.

As discussed in #811 and #814 the recent changes in 77df9c2b7110b370cfb6608aed333e0777951622 prevent some users who have set non-standard `scope-id` and `scope` combinations from using `config:delete`.

Additionally if these _non-standard_ `scope-id` and `scope` combos are used `--all` isn't true to it's documentation. 

This PR adds a `--force` option to `config:delete` to avoid this lock-out. This option does two things:

1. When used without the `--all` option: the _"positive integer"_ validation of `scope-id` is skipped, allowing usage of `0` `scope-id` for both `websites` and `stores` scopes.

2. When used with the `--all` option: `true` is passed to [`Mage::app()->getStores()`](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Core/Model/App.php#L891-L914) and [`Mage::app()->getWebsites()`](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Core/Model/App.php#L984-L1002) to include default stores and websites in the enumeration. This makes `--all` true to it's documentation.

**Update**

`config:set` also uses the same validation logic. https://github.com/netz98/n98-magerun/pull/815/commits/666b5f8b9d6140a2b01c97df011909a6b5d6ed35 adds a `--force` option to `config:set` to as in 1. above.