### PR TITLE
Fixes a rare PHP notice in the dev:module:list command.

### DIFF
--- a/src/N98/Magento/Command/Developer/Module/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/ListCommand.php
@@ -63,21 +63,15 @@ class ListCommand extends AbstractMagentoCommand
     {
         $modules = \Mage::app()->getConfig()->getNode('modules')->asArray();
         foreach ($modules as $moduleName => $moduleInfo) {
-
-            // skip modules which don't have a codePool or an active definition
-            if (!array_key_exists('codePool', $moduleInfo)
-                || !array_key_exists('active', $moduleInfo)
-            ) {
-                continue;
-            }
+            $codePool = isset($moduleInfo['codePool']) ? $moduleInfo['codePool'] : '';
+            $version  = isset($moduleInfo['version'])  ? $moduleInfo['version']  : '';
+            $active   = isset($moduleInfo['active'])   ? $moduleInfo['active']   : '';
 
             $this->infos[] = array(
-                'codePool' => $this->sanitizeModuleProperty($moduleInfo['codePool']),
+                'codePool' => $this->sanitizeModuleProperty($codePool),
                 'Name'     => $this->sanitizeModuleProperty($moduleName),
-                'Version'  => isset($moduleInfo['version'])
-                    ? $this->sanitizeModuleProperty($moduleInfo['version'])
-                    : '',
-                'Status'   => $this->formatActive($moduleInfo['active']),
+                'Version'  => $this->sanitizeModuleProperty($version),
+                'Status'   => $this->formatActive($active),
             );
         }
     }

--- a/src/N98/Magento/Command/Developer/Module/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/ListCommand.php
@@ -63,6 +63,14 @@ class ListCommand extends AbstractMagentoCommand
     {
         $modules = \Mage::app()->getConfig()->getNode('modules')->asArray();
         foreach ($modules as $moduleName => $moduleInfo) {
+
+            // skip modules which don't have a codePool or an active definition
+            if (!array_key_exists('codePool', $moduleInfo)
+                || !array_key_exists('active', $moduleInfo)
+            ) {
+                continue;
+            }
+
             $this->infos[] = array(
                 'codePool' => $this->sanitizeModuleProperty($moduleInfo['codePool']),
                 'Name'     => $this->sanitizeModuleProperty($moduleName),

--- a/src/N98/Magento/Command/Developer/Module/ListCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/ListCommand.php
@@ -52,7 +52,7 @@ class ListCommand extends AbstractMagentoCommand
 
         if (!empty($this->infos)) {
             $this->getHelper('table')
-                ->setHeaders(array('codePool', 'Name', 'Version', 'Status'))
+                ->setHeaders(array('Code pool', 'Name', 'Version', 'Status'))
                 ->renderByFormat($output, $this->infos, $input->getOption('format'));
         } else {
             $output->writeln("No modules match the specified criteria.");
@@ -68,10 +68,10 @@ class ListCommand extends AbstractMagentoCommand
             $active   = isset($moduleInfo['active'])   ? $moduleInfo['active']   : '';
 
             $this->infos[] = array(
-                'codePool' => $this->sanitizeModuleProperty($codePool),
-                'Name'     => $this->sanitizeModuleProperty($moduleName),
-                'Version'  => $this->sanitizeModuleProperty($version),
-                'Status'   => $this->formatActive($active),
+                'Code pool' => $this->sanitizeModuleProperty($codePool),
+                'Name'      => $this->sanitizeModuleProperty($moduleName),
+                'Version'   => $this->sanitizeModuleProperty($version),
+                'Status'    => $this->formatActive($active),
             );
         }
     }


### PR DESCRIPTION
### Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

### Subject:

Fixes a rare PHP notice in the `dev:module:list` command.

### Changes proposed in this pull request:

One of the modules in our shops has this module xml file:
```xml
<config>
    <modules>
        <!-- disable old Ogone extension -->
        <Mage_Ogone>
            <active>false</active>
        </Mage_Ogone>

        <Netresearch_OPS>
            <active>true</active>
            <codePool>community</codePool>
            <depends>
                <Mage_Sales/>
                <Mage_Payment/>
            </depends>
        </Netresearch_OPS>
    </modules>
</config>
```

The `Mage_Ogone` module referenced here was initially included in older Magento versions (like CE 1.4 and CE 1.5 if I remember correctly).
The `Netresearch_OPS` module integrates with the same Payment Provider, and they decided to disable the default module which came with Magento.
In newer versions of Magento, the `Mage_Ogone` is no longer is included.

So, on a newer Magento version, if you run the `dev:module:list` command, it will find the `Mage_Ogone` module, but since it hasn't got a `codePool` defined, we get this PHP notice in the `system.log` file:
`ERR (3): Notice: Undefined index: codePool  in n98-magerun.phar/src/N98/Magento/Command/Developer/Module/ListCommand.php on line 67`

This PR fixes this notice, by first checking if the module definition has at least a `codePool` and `active` flag defined, otherwise it will skip the module in the output. I think this makes sense, because if neither of those definitions are set, the module won't be active in Magento and it doesn't make sense to output it in the module definition.
If you disagree with this, let me know, maybe we can still output the module, but with a warning about it missing some definitions or something like that.

I know this is a very rare case, so if you want to ignore this PR, no problem!