### PR TITLE
Adds command to list transactional email template usage.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -86,6 +86,7 @@ commands:
     - N98\Magento\Command\Database\Maintain\CheckTablesCommand
     - N98\Magento\Command\Design\DemoNoticeCommand
     - N98\Magento\Command\Developer\Code\Model\MethodCommand
+    - N98\Magento\Command\Developer\EmailTemplate\UsageCommand
     - N98\Magento\Command\Developer\Ide\PhpStorm\MetaCommand
     - N98\Magento\Command\Developer\Setup\Script\AttributeCommand
     - N98\Magento\Command\Developer\ConsoleCommand

--- a/readme.rst
+++ b/readme.rst
@@ -1111,6 +1111,15 @@ Toggle profiler for debugging a store:
 
    $ n98-magerun.phar dev:profiler [--on] [--off] [--global] [store]
 
+Email Template Usage
+""""""""""""""""""""
+
+Display a report of use transactional email templates:
+
+.. code-block:: sh
+
+   $ n98-magerun.phar dev:email-template:usage --format[=FORMAT]
+
 Development Logs
 """"""""""""""""
 

--- a/src/N98/Magento/Command/Developer/EmailTemplate/UsageCommand.php
+++ b/src/N98/Magento/Command/Developer/EmailTemplate/UsageCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace N98\Magento\Command\Developer\EmailTemplate;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Mage;
+use Mage_Adminhtml_Model_Email_Template;
+
+class UsageCommand extends AbstractMagentoCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('dev:email-template:usage')
+            ->setDescription('Display database transactional email template usage')
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            )
+        ;
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        $this->initMagento();
+        $templates = $this->findEmailTemplates();
+
+        if (!empty($templates)) {
+            $this->getHelper('table')
+                ->setHeaders(array('id', 'Name', 'Scope', 'Scope Id', 'Path'))
+                ->renderByFormat($output, $templates, $input->getOption('format'));
+        } else {
+            $output->writeln("No transactional email templates stored in the database.");
+        }
+    }
+
+    protected function findEmailTemplates()
+    {
+        $templates = Mage::getModel('adminhtml/email_template')->getCollection();
+
+        $return = array();
+
+        foreach ($templates as $template) {
+
+            /**
+             * Some modules overload the template class so that the method getSystemConfigPathsWhereUsedCurrently
+             * is not available, this is a workaround for that
+             */
+            if (!method_exists($template, 'getSystemConfigPathsWhereUsedCurrently')) {
+                $instance = new Mage_Adminhtml_Model_Email_Template();
+                $template = $instance->load($template->getId());
+            }
+
+            $configPaths = $template->getSystemConfigPathsWhereUsedCurrently();
+
+            if (!count($configPaths)) {
+                $configPaths[]  = array(
+                    'scope'         => 'Unused',
+                    'scope_id'      => 'Unused',
+                    'path'          => 'Unused',
+                );
+            }
+
+            foreach ($configPaths as $configPath) {
+                $return[] = array(
+                    'id'            => $this->sanitizeEmailProperty($template->getId()),
+                    'Template Code' => $this->sanitizeEmailProperty($template->getTemplateCode()),
+                    'Scope'         => $this->sanitizeEmailProperty($configPath['scope']),
+                    'Scope Id'      => $this->sanitizeEmailProperty($configPath['scope_id']),
+                    'Path'          => $this->sanitizeEmailProperty($configPath['path']),
+                );
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * @param string $input Module property to be sanitized
+     *
+     * @return string
+     */
+    private function sanitizeEmailProperty($input)
+    {
+        return trim($input);
+    }
+}


### PR DESCRIPTION
Adds command to list transactional email template usage.

When an installation has many transactional emails, it is easy
to lose track of which ones are currently being used. As you can
also fall back to using templates in the source code, it is helpful
to be able to see which email templates are in use and which can be deleted.

This command allows you to see which email templates are used, and in
which scopes of the configuration that is.

I've not added unit tests, let me know if these are required and I'll get them written.