### PR TITLE
Additional tables in customer data strip

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -512,7 +512,7 @@ commands:
 
       - id: customers
         description: Customer data - Should not be used without @sales
-        tables: customer_address* customer_entity* wishlist*
+        tables: customer_address* customer_entity* wishlist* salesrule_coupon_usage salesrule_customer
 
       - id: newsletter
         description: Newsletter subscriber data

--- a/config.yaml
+++ b/config.yaml
@@ -508,11 +508,11 @@ commands:
 
       - id: sales
         description: Sales data (orders, invoices, creditmemos etc)
-        tables: sales_order_aggregated* sales_order_tax* sales_flat* sales_recurring_* sales_refunded_* sales_payment_* enterprise_sales_* enterprise_customer_sales_* sales_bestsellers_*
+        tables: sales_order_aggregated* sales_order_tax* sales_flat* sales_recurring_* sales_refunded_* sales_payment_* enterprise_sales_* enterprise_customer_sales_* sales_bestsellers_* salesrule_coupon_usage salesrule_customer
 
       - id: customers
         description: Customer data - Should not be used without @sales
-        tables: customer_address* customer_entity* wishlist* salesrule_coupon_usage salesrule_customer
+        tables: customer_address* customer_entity* wishlist*
 
       - id: newsletter
         description: Newsletter subscriber data


### PR DESCRIPTION
Subject: Add two tables to be stripped when using the @customers directive 

Fixes: 
Fatal error (FK constraint violations) when using the Enterprise backup functionality on a database which was dumped by N98 with customer data stripping. The salesrule_coupon_usage and salesrule_customer tables both reference customer_entity.