### PR TITLE
Adding model::method to cron list command

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -22,7 +22,11 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
         $jobs = $this->getJobConfigElements();
 
         foreach ($jobs as $name => $job) {
-            $table[$name] = array('Job' => $name) + $this->getSchedule($job);
+            $model = null;
+            if (isset($job->run) && isset($job->run->model)) {
+                $model = $job->run->model;
+            }
+            $table[$name] = array('Job' => $name, 'Model' => $model) + $this->getSchedule($job);
         }
 
         ksort($table, SORT_STRING);


### PR DESCRIPTION
Changes proposed in this pull request:

- Adds `Model` column to `sys:cron:list` command, showing the model::method that the job uses.

e.g.

![before](https://i.imgur.com/CVV1bvb.png)

changes to

![after](https://i.imgur.com/PTaO8IS.png)