### PR TITLE
Print out cron exceptions

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -99,6 +99,7 @@ HELP;
                     ->setMessages($e->getMessage())
                     ->setFinishedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                     ->save();
+                throw $e;
             }
 
             $output->writeln('<info>done</info>');


### PR DESCRIPTION
Magerun pull-request check-list:
- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

I was running a cron via the CLI yesterday and didn't realise it was throwing an exception. This change makes it so that exceptions are output to the command line.

Output Before:

```
Run Namespace_Module_Model_Cron::run
done
```

Output After:

```
Run Namespace_Module_Model_Cron::run
                                                 
  [Mage_Core_Exception]                          
  Exception Message Here
                                                 
sys:cron:run [job]
```

Running the command with `-v` will also print out the stack trace.