### PR TITLE
Add option to reinitialise cache when cleaning or flushing

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -685,13 +685,17 @@ If you would like to clean only one cache type:
 
 .. code-block:: sh
 
-   $ n98-magerun.phar cache:clean [code]
+   $ n98-magerun.phar cache:clean [--reinit] [--no-reinit] [<code>]
 
 If you would like to clean multiple cache types at once:
 
 .. code-block:: sh
 
-   $ n98-magerun.phar cache:clean [code] [code] ...
+   $ n98-magerun.phar cache:clean [--reinit] [--no-reinit] [<code>] [<code>] ...
+
+Options:
+    --reinit Reinitialise the config cache after cleaning (Default)
+    --no-reinit Don't reinitialise the config cache after cleaning. This will override --reinit.
 
 If you would like to remove all cache entries use `cache:flush`
 
@@ -700,9 +704,15 @@ Run `cache:list` command to see all codes.
 Remove all cache entries
 """"""""""""""""""""""""
 
+Flush the entire cache.
+
 .. code-block:: sh
 
-   $ n98-magerun.phar cache:flush
+   $ n98-magerun.phar cache:flush [--reinit] [--no-reinit]
+
+Options:
+    --reinit Reinitialise the config cache after flushing (Default)
+    --no-reinit Don't reinitialise the config cache after flushing. This will override --reinit.
 
 List Magento caches
 """""""""""""""""""

--- a/src/N98/Magento/Command/Cache/CleanCommand.php
+++ b/src/N98/Magento/Command/Cache/CleanCommand.php
@@ -4,6 +4,7 @@ namespace N98\Magento\Command\Cache;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanCommand extends AbstractCacheCommand
@@ -13,6 +14,18 @@ class CleanCommand extends AbstractCacheCommand
         $this
             ->setName('cache:clean')
             ->addArgument('type', InputArgument::IS_ARRAY | InputArgument::OPTIONAL, 'Cache type code like "config"')
+            ->addOption(
+                'reinit',
+                null,
+                InputOption::VALUE_NONE,
+                'Reinitialise the config cache after cleaning'
+            )
+            ->addOption(
+                'no-reinit',
+                null,
+                InputOption::VALUE_NONE,
+                "Don't reinitialise the config cache after flushing"
+            )
             ->setDescription('Clean magento cache')
         ;
 
@@ -29,6 +42,9 @@ If you would like to clean multiple cache types at once use like:
 
 If you would like to remove all cache entries use `cache:flush`
 
+Options:
+    --reinit Reinitialise the config cache after cleaning (Default)
+    --no-reinit Don't reinitialise the config cache after cleaning
 HELP;
         $this->setHelp($help);
     }
@@ -41,7 +57,11 @@ HELP;
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->banUseCache();
+        $noReinitOption = $input->getOption('no-reinit');
+        if (!$noReinitOption) {
+            $this->banUseCache();
+        }
+
         $this->detectMagento($output, true);
         if (!$this->initMagento()) {
             return;
@@ -61,6 +81,8 @@ HELP;
             }
         }
 
-        $this->reinitCache();
+        if (!$noReinitOption) {
+            $this->reinitCache();
+        }
     }
 }

--- a/src/N98/Magento/Command/Cache/FlushCommand.php
+++ b/src/N98/Magento/Command/Cache/FlushCommand.php
@@ -3,6 +3,7 @@
 namespace N98\Magento\Command\Cache;
 
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class FlushCommand extends AbstractCacheCommand
@@ -11,8 +12,31 @@ class FlushCommand extends AbstractCacheCommand
     {
         $this
             ->setName('cache:flush')
+            ->addOption(
+                'reinit',
+                null,
+                InputOption::VALUE_NONE,
+                'Reinitialise the config cache after flushing'
+            )
+            ->addOption(
+                'no-reinit',
+                null,
+                InputOption::VALUE_NONE,
+                "Don't reinitialise the config cache after flushing"
+            )
             ->setDescription('Flush magento cache storage')
         ;
+
+        $help = <<<HELP
+Flush the entire cache.
+
+   $ n98-magerun.phar cache:flush [--reinit --no-reinit]
+
+Options:
+    --reinit Reinitialise the config cache after flushing (Default)
+    --no-reinit Don't reinitialise the config cache after flushing
+HELP;
+        $this->setHelp($help);
     }
 
     /**
@@ -25,7 +49,10 @@ class FlushCommand extends AbstractCacheCommand
     {
         $this->detectMagento($output, true);
 
-        $this->banUseCache();
+        $noReinitOption = $input->getOption('no-reinit');
+        if (!$noReinitOption) {
+            $this->banUseCache();
+        }
 
         if (!$this->initMagento()) {
             return;
@@ -40,7 +67,9 @@ class FlushCommand extends AbstractCacheCommand
             $output->writeln('<error>Failed to clear Cache</error>');
         }
 
-        $this->reinitCache();
+        if (!$noReinitOption) {
+            $this->reinitCache();
+        }
 
         /* Since Magento 1.10 we have an own cache handler for FPC */
         if ($this->isEnterpriseFullPageCachePresent()) {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: Add option to reinitialise cache when cleaning or flushing

Previously the config cache would always be reinitialised when cleaning
or flushing. This was done to resolve a corner case issue with the
changing of database credentials. As the majority of the time no
reinitialisation is required, we move it into a --reinit option, making
cache cleaning much faster, and less prone to error.
    
It should be noted that the method used for reinitialisation of the
config cache will reliably corrupt the config cache when using redis.
There is a "reinit" method in the Mage_Core_Model_Config class which
will reinitialise the config cache and not cause any corruption.However,
instead of changing the method used to rebuild the config cache, this
patch simply puts the automatic rebuild behind an optional flag, as the
config cache reinitialisation is not required when clearing other caches.
