### PR TITLE
Rewrite conflicts annotation 

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1326,6 +1326,8 @@ The command checks class inheritance in order of your module dependencies.
 
 * If a filename with `--log-junit` option is set the tool generates an XML file and no output to *stdout*.
 
+When a fix for a merge conflict is introduced by creating another rewrite conflict, you can mark it as completed using an annotation. The annotation should be in the form (for example) `@SolvesRewriteConflict(catalog/product,First_ModuleWithConflict_Model_Catalog_Product, Second_ModuleWithConflict_Model_Catalog_Product, X_ModuleWithConflict_Model_Catalog_Product)`.
+
 Module Dependencies
 """""""""""""""""""
 

--- a/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
+++ b/src/N98/Magento/Command/Developer/Module/Rewrite/ConflictsCommand.php
@@ -63,6 +63,10 @@ HELP;
                     continue;
                 }
 
+                if ($this->_isARewriteFixingTheConflict($rewriteClasses, $class)) {
+                    continue;
+                }
+
                 $conflicts[] = array(
                     'Type'         => $type,
                     'Class'        => $class,
@@ -160,6 +164,45 @@ HELP;
                 }
             } catch (Exception $e) {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if one of the rewritten classes actually is written to fix the conflict.
+     * We can check by checking for an annotation in the PHPDOC block (@SolvesRewriteConflict)
+     *
+     * @var array $rewriteClasses
+     * @var string $rewrittenClass
+     * @return bool
+     */
+    protected function _isARewriteFixingTheConflict($rewriteClasses, $rewrittenClass)
+    {
+        foreach ($rewriteClasses as $rewriteClass) {
+            $r = new \ReflectionClass($rewriteClass);
+            $doc = $r->getDocComment();
+            preg_match_all('#@(.*?)\n#s', $doc, $annotations);
+
+            foreach ($annotations as $annotation) {
+                if (stripos($annotation[0], 'SolvesRewriteConflict') === 0) {
+                    preg_match('/SolvesRewriteConflict\((.*)\)/', $annotation[0], $matches);
+
+                    $classesInAnnotation = array_map('trim', explode(',', $matches[1]));
+                    $firstClassInAnnotation = array_shift($classesInAnnotation);
+                    $rewriteClassesWithoutCurrentClass = array_diff($rewriteClasses, array($rewriteClass));
+
+                    /* Check if all the conflicted classes are actually mentioned in the annotation,
+                     * another conflict could later have been introduced.
+                     */
+                    if (count($classesInAnnotation) > 1
+                        && $firstClassInAnnotation == $rewrittenClass
+                        && count(array_diff($rewriteClassesWithoutCurrentClass, $classesInAnnotation)) === 0
+                    ) {
+                        return true;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Magerun pull-request check-list:
- [X] Pull request against develop branch
- [X] readme.rst reflects changes 

Subject:    Check if one of the rewritten classes actually is written to fix the conflict.

Changes proposed in this pull request:

Check if one of the rewritten classes actually is written to fix the conflict in the list. 

When a fix for a merge conflict is introduced by creating another rewrite conflict, you can mark it as solved using an annotation. The annotation should be in the form (for example) `@SolvesRewriteConflict(catalog/product,First_ModuleWithConflict_Model_Catalog_Product, Second_ModuleWithConflict_Model_Catalog_Product, X_ModuleWithConflict_Model_Catalog_Product)`.
