### PR TITLE
Adding Magento 1.9.3.0 from the Magento Mirror

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -281,6 +281,15 @@ commands:
         extra:
           sample-data: sample-data-1.6.1.0
 
+      - name: magento-mirror-1.9.3.0
+        version: 1.9.3.0
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.9.3.0.zip
+          type: zip
+          shasum: a1f18d56c03f74207a712b12b2d93d7c524d1f1d
+        extra:
+          sample-data: sample-data-1.9.1.0
+
       - name: magento-mirror-1.9.2.4
         version: 1.9.2.4
         dist:


### PR DESCRIPTION
Added Magento 1.9.3.0 to config.yaml and confirmed it works so the install command can now utilize 1.9.3.0. 