### PR TITLE
Set created_at in schedule when running a cron job

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -84,6 +84,7 @@ HELP;
                 $schedule
                     ->setJobCode($jobCode)
                     ->setStatus(\Mage_Cron_Model_Schedule::STATUS_RUNNING)
+                    ->setCreatedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                     ->setExecutedAt(strftime('%Y-%m-%d %H:%M:%S', time()))
                     ->save();
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch
- [x] ~README.md reflects changes~ *(no need for such a small change IMO)*

Subject: Created_at did not get set in `sys:cron:run`

Changes proposed in this pull request:

- Set `created_at` in `cron_schedule` table when running a cron job. Otherwise the `created_at` field gtes set to `'0000-00-00 00:00:00'` in MySQL.