### PR TITLE
[fix] config.yaml - new command not added or override by previous commit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -60,6 +60,7 @@ commands:
     - N98\Magento\Command\Cache\ListCommand
     - N98\Magento\Command\Cache\ReportCommand
     - N98\Magento\Command\Cache\ViewCommand
+    - N98\Magento\Command\Category\Create\DummyCommand
     - N98\Magento\Command\Cms\Banner\ToggleCommand
     - N98\Magento\Command\Cms\Block\ToggleCommand
     - N98\Magento\Command\Cms\Page\PublishCommand
@@ -118,6 +119,7 @@ commands:
     - N98\Magento\Command\Developer\Translate\InlineShopCommand
     - N98\Magento\Command\Developer\Translate\SetCommand
     - N98\Magento\Command\Developer\Translate\ExportCommand
+    - N98\Magento\Command\Eav\Attribute\Create\DummyCommand
     - N98\Magento\Command\Eav\Attribute\ListCommand
     - N98\Magento\Command\Eav\Attribute\RemoveCommand
     - N98\Magento\Command\Eav\Attribute\ViewCommand


### PR DESCRIPTION
Changes proposed in this pull request:

New `eav:attribute:create-dummy-values` and `category:create:dummy` not show in command list because config,yaml was not update or override on master branch