### PR TITLE
Add enterprise mview reindex commands

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -128,7 +128,9 @@ commands:
     - N98\Magento\Command\GiftCard\RemoveCommand
     - N98\Magento\Command\GiftCard\Pool\GenerateCommand
     - N98\Magento\Command\Indexer\ListCommand
+    - N98\Magento\Command\Indexer\ListMviewCommand
     - N98\Magento\Command\Indexer\ReindexAllCommand
+    - N98\Magento\Command\Indexer\ReindexMviewCommand
     - N98\Magento\Command\Indexer\ReindexCommand
     - N98\Magento\Command\Installer\InstallCommand
     - N98\Magento\Command\Installer\UninstallCommand

--- a/readme.rst
+++ b/readme.rst
@@ -565,6 +565,25 @@ Loops all Magento indexes and triggers reindex.
 
    $ n98-magerun.phar index:reindex:all
 
+List Enterprise Mview Changelog Indexes
+"""""""""""""""""""""""""""""""""""""""
+
+Lists the Mview indexers available, as well as their current version and how many are in the changelog queue .
+
+.. code-block:: sh
+
+   $ n98-magerun.phar index:list:mview [--format[="..."]]
+
+Reindex an Enterprise Mview Changelog Index
+"""""""""""""""""""""""""""""""""""""""""""
+
+Index by Mview table code. This will ignore all locks and trigger the changelog indexer.
+
+.. code-block:: sh
+
+   $ n98-magerun.phar index:reindex:mview [table_code]
+
+
 Generate local.xml file
 """""""""""""""""""""""
 

--- a/src/N98/Magento/Command/AbstractMagentoCommand.php
+++ b/src/N98/Magento/Command/AbstractMagentoCommand.php
@@ -383,6 +383,38 @@ abstract class AbstractMagentoCommand extends Command
      *
      * @param string $mage1code Magento 1 class code
      * @param string $mage2class Magento 2 class name
+     * @return \Mage_Core_Helper_Abstract
+     */
+    protected function _getHelper($mage1code, $mage2class)
+    {
+        if ($this->_magentoMajorVersion == self::MAGENTO_MAJOR_VERSION_2) {
+            return \Mage::helper($mage2class);
+        } else {
+            return \Mage::helper($mage1code);
+        }
+    }
+
+    /**
+     * Magento 1 / 2 switches
+     *
+     * @param string $mage1code Magento 1 class code
+     * @param string $mage2class Magento 2 class name
+     * @return \Mage_Core_Model_Abstract
+     */
+    protected function _getSingleton($mage1code, $mage2class)
+    {
+        if ($this->_magentoMajorVersion == self::MAGENTO_MAJOR_VERSION_2) {
+            return \Mage::getModel($mage2class);
+        } else {
+            return \Mage::getModel($mage1code);
+        }
+    }
+
+    /**
+     * Magento 1 / 2 switches
+     *
+     * @param string $mage1code Magento 1 class code
+     * @param string $mage2class Magento 2 class name
      * @return \Mage_Core_Model_Abstract
      */
     protected function _getResourceModel($mage1code, $mage2class)

--- a/src/N98/Magento/Command/Indexer/AbstractMviewIndexerCommand.php
+++ b/src/N98/Magento/Command/Indexer/AbstractMviewIndexerCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace N98\Magento\Command\Indexer;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+
+class AbstractMviewIndexerCommand extends AbstractMagentoCommand
+{
+    /**
+     * @return \Enterprise_Mview_Model_Resource_Metadata_Collection
+     */
+    public function getMetaDataCollection()
+    {
+        $collection = $this->_getModel('enterprise_mview/metadata')->getCollection();
+        return $collection;
+    }
+
+    /**
+     * @return array[]
+     */
+    protected function getIndexers()
+    {
+        /** @var \Enterprise_Index_Helper_Data $helper */
+        $helper = $this->_getHelper('enterprise_index');
+
+        $indexers = array();
+        foreach ($helper->getIndexers(true) as $indexer) {
+            $indexers[(string) $indexer->index_table] = $indexer;
+        }
+
+        foreach ($indexers as $indexerKey => $indexerData) {
+            if (!isset($indexerData->action_model->changelog)) {
+                unset($indexers[$indexerKey]);
+            }
+        }
+
+        return $indexers;
+    }
+
+    /**
+     * @return \Enterprise_Mview_Model_Client
+     */
+    protected function getMviewClient()
+    {
+        return $this->_getModel('enterprise_mview/client');
+    }
+}

--- a/src/N98/Magento/Command/Indexer/ListMviewCommand.php
+++ b/src/N98/Magento/Command/Indexer/ListMviewCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace N98\Magento\Command\Indexer;
+
+use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListMviewCommand extends AbstractMviewIndexerCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('index:list:mview')
+            ->setDescription('Lists all magento mview indexes')
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            )
+        ;
+
+        $help = <<<HELP
+Lists all Magento mview indexers of current installation.
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $table = array();
+        foreach ($this->getMetaDataCollection() as $index) {
+            $changelogName = $index->getData('changelog_name');
+            $versionId = $index->getData('version_id');
+            $pendingCount = $this->getPendingChangelogsCount($changelogName, $versionId);
+            if ($pendingCount > 0) {
+                $pendingString = "<error>$pendingCount</error>";
+            } else {
+                $pendingString = "<info>$pendingCount</info>";
+            }
+
+            $table[] = array(
+                $index->getData('table_name'),
+                $index->getData('view_name'),
+                $changelogName,
+                $index->getData('status'),
+                $versionId,
+                $pendingString,
+            );
+        }
+
+        $this->getHelper('table')
+            ->setHeaders(
+                array(
+                    'table_name',
+                    'view_name',
+                    'changelog_name',
+                    'status',
+                    'version_id',
+                    'entries pending reindex',
+                )
+            )
+            ->renderByFormat($output, $table, $input->getOption('format'));
+    }
+
+    /**
+     * @param $tableName
+     * @param $currentVersionId
+     * @return int
+     */
+    protected function getPendingChangelogsCount($tableName, $currentVersionId)
+    {
+        /** @var \Mage_Core_Model_Resource $resource */
+        $resource = $this->_getSingleton('core/resource');
+        $readConnection = $resource->getConnection('core_read');
+
+        $select = $readConnection->select()
+            ->from($tableName, array('count(*)'))
+            ->where("version_id > ?", $currentVersionId);
+        $todoCount = $readConnection->fetchOne($select);
+
+        return (int) $todoCount;
+    }
+}

--- a/src/N98/Magento/Command/Indexer/ReindexMviewCommand.php
+++ b/src/N98/Magento/Command/Indexer/ReindexMviewCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace N98\Magento\Command\Indexer;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ReindexMviewCommand extends AbstractMviewIndexerCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('index:reindex:mview')
+            ->addArgument('table_name', InputArgument::REQUIRED, 'View table name"')
+            ->setDescription('Reindex a magento index by code using the materialised view functionality');
+
+        $help = <<<HELP
+Trigger a mview index by table_name.
+
+   $ n98-magerun.phar index:reindex:mview [table_name]
+HELP;
+        $this->setHelp($help);
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+        $tableName = $input->getArgument('table_name');
+
+        $indexers = $this->getIndexers();
+
+        if (!array_key_exists($tableName, $indexers)) {
+            throw new \InvalidArgumentException("$tableName is not a view table");
+        }
+
+        $indexerData = $indexers[$tableName];
+        $indexTable = (string) $indexerData->index_table;
+        $actionName = (string) $indexerData->action_model->changelog;
+
+        $client = $this->getMviewClient();
+        $client->init($indexTable);
+        if (!$client->getMetadata()->getId()) {
+            throw new \InvalidArgumentException("Could not load metadata for $tableName");
+        }
+
+        $output->writeln("<info>Starting mview indexer <comment>{$indexTable}</comment> with action <comment>{$actionName}</comment> </info>");
+        $client->execute($actionName);
+        $output->writeln("<info>Done</info>");
+    }
+}


### PR DESCRIPTION
I've spent too long in my time as a Magento developer teaching the members on my team that the full flat indexer, and the changlog (mview) reindexer do vastly different things under the hood. It's fine to have your product reappear on the frontend when running a full reindex, but when you have to debug and fix something in the changelog process you need a finer level of granularity. Having to debug these on local, production, and every environment in between has left me wanting a standard command to handle this.

I've added two.

1. Show a list of the mview metadata, including how many entries are pending a reindex (can be useful if an indexer gets stuck)

```bash
$ magerun index:list:mview

+---------------------------------+------------------------------------+------------------------------------+--------+------------+-------------------------+
| table_name                      | view_name                          | changelog_name                     | status | version_id | entries pending reindex |
+---------------------------------+------------------------------------+------------------------------------+--------+------------+-------------------------+
| cataloginventory_stock_status   | cataloginventory_stock_status_view | cataloginventory_stock_status_cl   | 1      | 5262044    | 0                       |
| enterprise_url_rewrite_redirect | enterprise_url_rewrite_redirect    | enterprise_url_rewrite_redirect_cl | 1      | 4117       | 0                       |
| enterprise_url_rewrite_category | enterprise_url_rewrite_category    | enterprise_url_rewrite_category_cl | 1      | 73207      | 0                       |
| enterprise_url_rewrite_product  | enterprise_url_rewrite_product     | enterprise_url_rewrite_product_cl  | 1      | 29065      | 1                       |
| catalog_category_product_index  | catalog_category_product_view      | catalog_category_product_index_cl  | 1      | 455375     | 0                       |
| catalog_category_product_cat    | catalog_category_product_cat_view  | catalog_category_product_cat_cl    | 1      | 78188      | 0                       |
| catalog_product_index_price     | catalog_product_index_price_view   | catalog_product_index_price_cl     | 1      | 12189944   | 0                       |
| catalog_category_flat           | catalog_category_view              | catalog_category_flat_cl           | 1      | 107413     | 0                       |
| catalog_product_flat            | catalog_product_view               | catalog_product_flat_cl            | 2      | 0          | 0                       |
+---------------------------------+------------------------------------+------------------------------------+--------+------------+-------------------------+
```

2. Trigger a  mview changelog reindex for a given table

```
$ magerun index:reindex:mview enterprise_url_rewrite_product
Starting mview indexer enterprise_url_rewrite_product with action enterprise_catalog/index_action_url_rewrite_product_refresh_changelog
Done
```

I know this logic is enterprise only, but I have seen other functions accessing enterprise models in the magerun core.
