### PR TITLE
Re #897 do not exit script on cache flush

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -134,6 +134,11 @@ class Application extends BaseApplication
     protected $_magentoDetected = false;
 
     /**
+     * @var bool
+     */
+    private static $_isScriptEnvironment = false;
+
+    /**
      * @param ClassLoader $autoloader
      */
     public function __construct($autoloader = null)
@@ -883,5 +888,20 @@ MAGENTOHINT;
     {
         $output->getFormatter()->setStyle('debug', new OutputFormatterStyle('magenta', 'white'));
         $output->getFormatter()->setStyle('warning', new OutputFormatterStyle('red', 'yellow', array('bold')));
+    }
+    /**
+     * @return bool
+     */
+    public function isScriptEnvironment()
+    {
+        return self::$_isScriptEnvironment;
+    }
+
+    /**
+     * @param $state bool
+     */
+    public function setScriptEnvironment($state)
+    {
+        self::$_isScriptEnvironment = $state;
     }
 }

--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -121,7 +121,7 @@ HELP;
         $script = $this->_getContent($this->_scriptFilename);
         $commands = explode("\n", $script);
         $this->initScriptVars();
-
+        $this->getApplication()->setScriptEnvironment(true);
         foreach ($commands as $commandString) {
             $commandString = trim($commandString);
             if (empty($commandString)) {

--- a/src/N98/Magento/Command/System/Setup/RunCommand.php
+++ b/src/N98/Magento/Command/System/Setup/RunCommand.php
@@ -138,7 +138,9 @@ HELP;
         $application = $this->getApplication();
         $application->setAutoExit(false);
         $application->run(new StringInput('cache:flush'), new NullOutput());
-        $application->setAutoExit(true);
+        if (!$application->isScriptEnvironment()){
+            $application->setAutoExit(true);
+        }
 
         /**
          * Restore initially loaded events which was reset during setup script run


### PR DESCRIPTION
when using n98-magerun script do not exit script on cache flush
This change is to fix side effect of fix done in #897
It adds static state to check if n98-magerun is running a script.
if it is running a script does not exit n98 application

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes #897 
Changes proposed in this pull request:

- Detect if script is running 

- Behave differently if script is being executed.

- ...
