### PR TITLE
Updates script command to have non-zero exit code

### DIFF
--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -266,7 +266,8 @@ HELP;
         $input = new StringInput($commandString);
         $exitCode = $this->getApplication()->run($input, $output);
         if ($exitCode !== 0 && $this->_stopOnError) {
-            throw new RuntimeException('Script stopped with errors');
+            $this->getApplication()->setAutoExit(true);
+            throw new RuntimeException('Script stopped with errors', $exitCode);
         }
     }
 


### PR DESCRIPTION
On a failed exectution with --stop-on-error specified, the script
command now throws a non zero exit code.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes #908 exit code should be non-zero if script command fails