### PR TITLE
Remove Duplicate entry in config.yaml for magento-mirror-1.9.3.2

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -348,14 +348,6 @@ commands:
           reference: master
         extra:
           sample-data: sample-data-1.6.1.0
-      - name: magento-mirror-1.9.3.2
-        version: 1.9.3.2
-        dist:
-          url: https://github.com/OpenMage/magento-mirror/archive/1.9.3.2.zip
-          type: zip
-          shasum: 8dccfa5a8ab6131f0e536e8c7269e5fb8559e03d
-        extra:
-          sample-data: sample-data-1.9.2.4
 
       - name: magento-mirror-1.9.3.2
         version: 1.9.3.2


### PR DESCRIPTION
Fix: InstallCommandPackageVersionTest.versionListing

(cherry picked from commit 35cf964)

