### PR TITLE
Show full path for phpstorm autocompletion folder

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -1741,7 +1741,7 @@ Detailed information is available in the bash-completions FAQ: https://github.co
 PHPStorm 8.0.*
 """"""""""""""
 
-A commandline tool autocompletion XML file for PHPStorm exists in subfolder **autocompletion/phpstorm**.
+A commandline tool autocompletion XML file for PHPStorm exists in subfolder **res/autocompletion/phpstorm**.
 Copy **n98_magerun.xml** into your phpstorm config folder.
 
 Linux and Mac: ~/.WebIde80/config/componentVersions


### PR DESCRIPTION
Clarified location context of phpstorm autocompletion directory.

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes # .

Changes proposed in this pull request:

- ...

- ...

- ...
