### PR TITLE
Added 1.9.3.3 and 1.9.3.4 to the install option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -178,6 +178,24 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
+      - name: magento-ce-1.9.3.4
+        version: 1.9.3.4
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.9.3.4.zip
+          type: zip
+          shasum: 6dadf8de337ae7033839839caeb15cbb2e98e4b8
+        extra:
+          sample-data: sample-data-1.9.2.4
+
+      - name: magento-ce-1.9.3.3
+        version: 1.9.3.3
+        dist:
+          url: https://github.com/OpenMage/magento-mirror/archive/1.9.3.3.zip
+          type: zip
+          shasum: f613968e1ea667ec1a0f0198b7c1d319e2598580
+        extra:
+          sample-data: sample-data-1.9.2.4
+
       - name: magento-ce-1.9.3.2
         version: 1.9.3.2
         dist:


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Subject: Added missing Magento versions

I added Magento versions 1.9.3.3 and 1.9.3.4 to the install command. They where available in the "mirror" section, but not in the main section.