### PR TITLE
Magento developer mode

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -228,6 +228,9 @@ Global config parameters:
       Do not load any custom config.
   --skip-root-check
       Do not check if n98-magerun runs as root.
+  --developer-mode
+      Instantiate Magento in Developer Mode
+
 
 Open Shop in Browser
 """"""""""""""""""""

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -119,6 +119,11 @@ class Application extends BaseApplication
     protected $_magerunStopFileFolder = null;
 
     /**
+     * @var null
+     */
+    protected $_magerunUseDeveloperMode = null;
+
+    /**
      * @var bool
      */
     protected $_isInitialized = false;
@@ -202,6 +207,17 @@ class Application extends BaseApplication
         );
         $inputDefinition->addOption($skipExternalConfig);
 
+        /**
+         * Developer Mode
+         */
+        $rootDirOption = new InputOption(
+            '--developer-mode',
+            '',
+            InputOption::VALUE_NONE,
+            'Instantiate Magento in Developer Mode'
+        );
+        $inputDefinition->addOption($rootDirOption);
+
         return $inputDefinition;
     }
 
@@ -249,6 +265,7 @@ class Application extends BaseApplication
         $this->_magentoMajorVersion = $magentoHelper->getMajorVersion();
         $this->_magerunStopFileFound = $magentoHelper->isMagerunStopFileFound();
         $this->_magerunStopFileFolder = $magentoHelper->getMagerunStopFileFolder();
+        $this->_magerunUseDeveloperMode = ($input->getParameterOption('--developer-mode'));
     }
 
     /**
@@ -772,6 +789,9 @@ class Application extends BaseApplication
         $initSettings = $this->config->getConfig('init');
 
         Mage::app($initSettings['code'], $initSettings['type'], $initSettings['options']);
+        if ($this->_magerunUseDeveloperMode) {
+            Mage::setIsDeveloperMode(true);
+        }
     }
 
     /**


### PR DESCRIPTION
### Magerun pull-request check-list:

- [x] Pull request against develop branch
- [x] README.md reflects changes 

### Changes proposed in this pull request:

#### Add `--developer-mode` flag

I added this flag while I was trying to debug #938, and although it didn't really help I thought I'd see what you think. 

This is instantiated in much the same way as it is when done via [`index.php`](https://github.com/OpenMage/magento-mirror/blob/magento-1.9/index.php#L70)

I think it may be useful when I plug `magerun sys:setup:run --developer-mode` into a `.travis.yml`, this way I can catch notices/warnings within dodgy setup scripts a lot easier.

#### ~~Update `.gitignore`~~

~~I just noticed that the `.idea` directory wasn't ignored, feel free to ask me to remove or cherrypick to ignore it if you don't think it's appropriate.~~