### PR TITLE
Add another fallback check to enterprise detection

### DIFF
--- a/src/N98/Util/Console/Helper/MagentoHelper.php
+++ b/src/N98/Util/Console/Helper/MagentoHelper.php
@@ -326,7 +326,8 @@ class MagentoHelper extends AbstractHelper
             if (is_callable(array('\Mage', 'getEdition'))) {
                 $this->_magentoEnterprise = (\Mage::getEdition() == 'Enterprise');
             } else {
-                $this->_magentoEnterprise = is_dir($this->_magentoRootFolder . '/app/code/core/Enterprise');
+                $this->_magentoEnterprise = is_dir($this->_magentoRootFolder . '/app/code/core/Enterprise') ||
+                    is_dir($this->_magentoRootFolder . '/app/design/frontend/enterprise/default/layout');
             }
 
             if (OutputInterface::VERBOSITY_DEBUG <= $this->output->getVerbosity()) {


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

See 
- https://github.com/netz98/n98-magerun/issues/938
- https://github.com/netz98/n98-magerun/issues/902

Add an additional fallback check for the enterprise layout directory

In 902 I said 
>For visibility there is no app/code/core/Enterprise folder as Enterprise lives under the /vendor directory for this project.

There is still an Enterprise frontend directory as there is no amount of autoloading shenanigans you can do to get them to work in a modern way.

The proposed change will
- Fix enterprise detection for my use case (#902)
- Fix the broken symfony/console errors people are seeing without having to require a change in workflow (#938)