### PR TITLE
Add cms:block:list command

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -63,6 +63,7 @@ commands:
     - N98\Magento\Command\Cache\ViewCommand
     - N98\Magento\Command\Category\Create\DummyCommand
     - N98\Magento\Command\Cms\Banner\ToggleCommand
+    - N98\Magento\Command\Cms\Block\ListCommand
     - N98\Magento\Command\Cms\Block\ToggleCommand
     - N98\Magento\Command\Cms\Page\PublishCommand
     - N98\Magento\Command\Config\DeleteCommand

--- a/readme.rst
+++ b/readme.rst
@@ -860,6 +860,15 @@ Toggle "is_active" on a cms block
 
 "block_id" can be an entity id or an "identifier"
 
+List CMS Blocks
+""""""""""""""""
+
+List all CMS blocks
+
+.. code-block:: sh
+
+   $ n98-magerun.phar cms:block:list [--format[="..."]]
+
 Demo Notice
 """""""""""
 

--- a/src/N98/Magento/Command/Cms/Block/ListCommand.php
+++ b/src/N98/Magento/Command/Cms/Block/ListCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace N98\Magento\Command\Cms\Block;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use N98\Util\Console\Helper\Table\Renderer\RendererFactory;
+use N98\Util\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * CMS Block ListCommand
+ *
+ * @package N98\Magento\Command\Cms\Block
+ */
+class ListCommand extends AbstractMagentoCommand
+{
+    /**
+     * Configure command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('cms:block:list')
+            ->setDescription('List all cms blocks')
+            ->addOption(
+                'format',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Output Format. One of [' . implode(',', RendererFactory::getFormats()) . ']'
+            )
+        ;
+    }
+
+    /**
+     * Get an instance of cms/block
+     *
+     * @return \Mage_Cms_Model_Block
+     */
+    protected function _getBlockModel()
+    {
+        return $this->_getModel('cms/block', '\Mage_Cms_Model_Block');
+    }
+
+    /**
+     * Execute the command
+     *
+     * @param InputInterface  $input
+     * @param OutputInterface $output
+     *
+     * @return int|null|void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output, true);
+        if (!$this->initMagento()) {
+            return;
+        }
+
+        $cmsBlockCollection = $this->_getBlockModel()->getCollection()->addFieldToSelect('*');
+
+        /** @var \Mage_Cms_Model_Resource_Block $resourceModel */
+        $resourceModel = $this->_getBlockModel()->getResource();
+
+        $table = array();
+        foreach ($cmsBlockCollection as $cmsBlock) {
+            $storeIds = implode(',', $resourceModel->lookupStoreIds($cmsBlock->getId()));
+
+            $table[] = array(
+                $cmsBlock->getData('block_id'),
+                $cmsBlock->getData('identifier'),
+                $cmsBlock->getData('title'),
+                $cmsBlock->getData('is_active') ? 'active' : 'inactive',
+                $storeIds,
+            );
+        }
+
+        /* @var $tableHelper TableHelper */
+        $tableHelper = $this->getHelper('table');
+        $tableHelper
+            ->setHeaders(array('block_id', 'identifier', 'title', 'is_active', 'store_ids'))
+            ->renderByFormat($output, $table, $input->getOption('format'));
+    }
+}


### PR DESCRIPTION
Add `cms:block:list` command which outputs like

```bash
/opt/boxen/phpenv/versions/5.5.38/bin/php /Users/lukerodgers/src/magerundemo/bin/n98-magerun --root-dir=/Users/lukerodgers/src/magento-mirror cms:block:list
+----------+---------------------------------+---------------------------+-----------+-----------+
| block_id | identifier                      | title                     | is_active | store_ids |
+----------+---------------------------------+---------------------------+-----------+-----------+
| 1        | footer_links                    | Footer Links              | active    | 0         |
| 2        | footer_links_company            | Footer Links Company      | active    | 0         |
| 3        | cookie_restriction_notice_block | Cookie restriction notice | active    | 0         |
| 4        | catalog_events_lister           | Catalog Events Lister     | active    | 0         |
+----------+---------------------------------+---------------------------+-----------+-----------+
```

`store_ids` are a comma-separated list of store ids.