### PR TITLE
Fixed typo in 'config:get' results when returning a 'null' value

### DIFF
--- a/src/N98/Magento/Command/Config/AbstractConfigCommand.php
+++ b/src/N98/Magento/Command/Config/AbstractConfigCommand.php
@@ -7,7 +7,7 @@ use N98\Magento\Command\AbstractMagentoCommand;
 
 abstract class AbstractConfigCommand extends AbstractMagentoCommand
 {
-    const DISPLAY_NULL_UNKOWN_VALUE = "NULL (NULL/\"unkown\" value)";
+    const DISPLAY_NULL_UNKNOWN_VALUE = "NULL (NULL/\"unknown\" value)";
 
     /**
      * @var array strings of configuration scopes

--- a/src/N98/Magento/Command/Config/GetCommand.php
+++ b/src/N98/Magento/Command/Config/GetCommand.php
@@ -160,7 +160,7 @@ HELP;
         if ($value === null) {
             switch ($format) {
                 case null:
-                    $value = self::DISPLAY_NULL_UNKOWN_VALUE;
+                    $value = self::DISPLAY_NULL_UNKNOWN_VALUE;
                     break;
                 case 'json':
                     break;

--- a/src/N98/Magento/Command/Config/SetCommand.php
+++ b/src/N98/Magento/Command/Config/SetCommand.php
@@ -40,7 +40,7 @@ class SetCommand extends AbstractConfigCommand
                 "no-null",
                 null,
                 InputOption::VALUE_NONE,
-                "Do not treat value NULL as " . self::DISPLAY_NULL_UNKOWN_VALUE . " value"
+                "Do not treat value NULL as " . self::DISPLAY_NULL_UNKNOWN_VALUE . " value"
             )
         ;
 
@@ -84,7 +84,7 @@ HELP;
                 throw new \InvalidArgumentException("Encryption is not possbile for NULL values");
             }
             $value = null;
-            $valueDisplay = self::DISPLAY_NULL_UNKOWN_VALUE;
+            $valueDisplay = self::DISPLAY_NULL_UNKNOWN_VALUE;
         } else {
             $value = str_replace(array('\n', '\r'), array("\n", "\r"), $value);
             $value = $this->_formatValue($value, ($input->getOption('encrypt') ? 'encrypt' : false));

--- a/tests/N98/Magento/Command/Config/GetCommandTest.php
+++ b/tests/N98/Magento/Command/Config/GetCommandTest.php
@@ -39,7 +39,7 @@ class GetCommandTest extends TestCase
                 'path'    => 'n98_magerun/foo/bar',
                 'value'   => 'NULL',
             ),
-            'n98_magerun/foo/bar => NULL (NULL/"unkown" value)'
+            'n98_magerun/foo/bar => NULL (NULL/"unknown" value)'
         );
 
         $this->assertDisplayContains(
@@ -47,7 +47,7 @@ class GetCommandTest extends TestCase
                 'command' => 'config:get',
                 'path'    => 'n98_magerun/foo/bar',
             ),
-            '| n98_magerun/foo/bar | default | 0        | NULL (NULL/"unkown" value) |'
+            '| n98_magerun/foo/bar | default | 0        | NULL (NULL/"unknown" value) |'
         );
 
         $this->assertDisplayContains(
@@ -63,7 +63,7 @@ class GetCommandTest extends TestCase
     public function provideFormatsWithNull()
     {
         return array(
-            array(null, '~\\Q| n98_magerun/foo/bar | default | 0        | NULL (NULL/"unkown" value) |\\E~'),
+            array(null, '~\\Q| n98_magerun/foo/bar | default | 0        | NULL (NULL/"unknown" value) |\\E~'),
             array('csv', '~\\Qn98_magerun/foo/bar,default,0,NULL\\E~'),
             array('json', '~"Value": *null~'),
             array('xml', '~\\Q<Value>NULL</Value>\\E~'),
@@ -85,7 +85,7 @@ class GetCommandTest extends TestCase
                 'path'    => 'n98_magerun/foo/bar',
                 'value'   => 'NULL',
             ),
-            'n98_magerun/foo/bar => NULL (NULL/"unkown" value)'
+            'n98_magerun/foo/bar => NULL (NULL/"unknown" value)'
         );
 
         $this->assertDisplayRegExp(


### PR DESCRIPTION
Magerun pull-request check-list:

[x] Pull request against develop branch (if not, just close and create a new one against it)
[x] README.md reflects changes (if any)
Subject: typo in 'config:get' when null value is returned

Fixes # .

Changes proposed in this pull request:

Typo in response message and class constants