### PR TITLE
Fix immediate execution of sys:cron:run

### DIFF
--- a/src/N98/Magento/Command/System/Cron/RunCommand.php
+++ b/src/N98/Magento/Command/System/Cron/RunCommand.php
@@ -62,10 +62,10 @@ HELP;
 
         $output->write('<info>Run </info><comment>' . $callableName . '</comment> ');
 
-        if (!$input->hasOption('schedule')) {
-            $this->executeConfigModel($callback, $jobCode);
-        } else {
+        if ($input->hasOption('schedule') && $input->getOption('schedule')) {
             $this->scheduleConfigModel($callback, $jobCode);
+        } else {
+            $this->executeConfigModel($callback, $jobCode);
         }
 
         $output->writeln('<info>done</info>');


### PR DESCRIPTION
Hello,

I use `sys:cron:run` occasionally to force a couple of cronjobs to execute outside of their window of execution and also to be able to break execution. Recently I noticed that the command was always being scheduled.

This patches fixes an issue introduced in #966 with the `--schedule` command switch. The `hasOption` method is always returning `true` which causes commands to always be scheduled instead of running immediately as default. The `executeConfigModel` and `scheduleConfigModel` was also
changed in order to avoid using `hasOption` and `!getOption` in the condition which would make it a bit harder to understand.

Also, having `hasOption && getOption` together keeps it consistent with how other commands operate (e.g. [cache:view](https://github.com/netz98/n98-magerun/blob/880b7a675028ca6d12c0b41854e3951c5d73eacd/src/N98/Magento/Command/Cache/ViewCommand.php#L42))

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Fixes #966

Changes proposed in this pull request:
- Check for hasOption and getOption to confirm that the switch is set by the user
- Change the condition to be easier to understand without two negations

Best regards,
Ricardo Velhote