### PR TITLE
chore: remove obsolete global DB env variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ php:
   - 5.5
 
 env:
-  global:
-    - DB=mysql
   matrix:
     - SCRIPT_JOB="PHP-CS-FIXER"
     - SCRIPT_JOB="BUILDSH"


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: 
Remove the now obsolete global DB env variable as per https://github.com/netz98/n98-magerun/pull/986#issuecomment-388976881

Changes proposed in this pull request:

- remove obsolete global `DB` env var for Travis CI