### PR TITLE
Don't strip newsletter templates when stripping subscribers

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -610,7 +610,7 @@ commands:
 
       - id: newsletter
         description: Newsletter subscriber data
-        tables: "newsletter_*"
+        tables: "newsletter_problem newsletter_queue* newsletter_subscriber"
 
       - id: trade
         description: Current trade data (customers and orders). You usally do not want those in developer systems.


### PR DESCRIPTION
Subject: Don't strip newsletter templates when stripping subscribers

Currently the tool strips the newsletter templates as well as the actual subscriber data (contrary to the description of the `@newsletter` and `@development` group descriptions). This avoids that.