### PR TITLE
Add shasum for 1.9.3.10

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -186,7 +186,7 @@ commands:
         dist:
           url: https://github.com/OpenMage/magento-mirror/archive/1.9.3.10.zip
           type: zip
-          shasum:
+          shasum: c4eb4a0728154cfdae2781c15d9a1405136efa1e
         extra:
           sample-data: sample-data-1.9.2.4
 


### PR DESCRIPTION
Was missing since https://github.com/OpenMage/magento-mirror/pull/69 wasn't merged yet. #999 was merged a little too soon, but this should fix the missing shasum.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes #998 .

Changes proposed in this pull request:

- Add missing shasum for 1.9.3.10