### PR TITLE
add openmage-lts to installable versions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -406,6 +406,15 @@ commands:
         extra:
           sample-data: sample-data-1.1.2
 
+      - name: openmage-lts-1.9.3.x
+        version: dev-1.9.3.x
+        source:
+          url: https://github.com/OpenMage/magento-lts.git
+          type: git
+          reference: 1.9.3.x
+        extra:
+          sample-data: sample-data-1.9.2.4
+
       - name: mageplus-master
         version: dev-master
         source:


### PR DESCRIPTION
As one of the most active Magento1 Forks, we would appreciate it to also get listed as part of the installable versions.
