### PR TITLE
Improvement: add default value for --add-time option

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -36,7 +36,8 @@ class DumpCommand extends AbstractDatabaseCommand
                 't',
                 InputOption::VALUE_OPTIONAL,
                 'Append or prepend a timestamp to filename if a filename is provided. ' .
-                'Possible values are "suffix", "prefix" or "no".'
+                'Possible values are "suffix", "prefix" or "no".',
+                true
             )
             ->addOption(
                 'compression',


### PR DESCRIPTION
Magerun pull-request check-list:

- [x ] Pull request against develop branch (if not, just close and create a new one against it)
- [x ] README.md reflects changes (if any)

Subject: Improvement: add default value for --add-time option

Fixes #974 .

Changes proposed in this pull request:

- add proper default value to --add-time option 

With symfony console 2.x default value is `null`. [See this ](https://symfony.com/doc/2.8/console/input.html#options-with-optional-arguments)

