### PR TITLE
Extra directory for plugins, see #1016

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ twig:
 
 plugin:
   folders:
+    - /usr/share/n98-magerun/modules
     - /usr/local/share/n98-magerun/modules
 
 helpers:


### PR DESCRIPTION
To be clear on the proposed change: the n98-magerun would scan /usr/share/n98-magerun/modules first, then /usr/local/share/n98-magerun/modules. That would sort of match other system conventions (when you have overrides in /usr/local and packages in /usr).

Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)