### PR TITLE
Phpstorm meta files - support dynamically called helpers + createBlock() methods

### DIFF
--- a/src/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommand.php
+++ b/src/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommand.php
@@ -56,6 +56,9 @@ class MetaCommand extends AbstractMagentoCommand
      * @var array
      */
     protected $methodFactories = array(
+        'blocks' => array(
+            '\Mage_Core_Model_Layout::createBlock',
+        ),
         'helpers' => array(
             '\Mage_Admin_Model_User::_getHelper',
             '\Mage_Adminhtml_Controller_Rss_Abstract::_getHelper',

--- a/src/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommand.php
+++ b/src/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommand.php
@@ -491,17 +491,6 @@ PHP;
             if ($input->getOption('stdout')) {
                 $output->writeln($map);
             } else {
-                $metaPath = $this->_magentoRootFolder . '/.phpstorm.meta.php';
-                if (is_file($metaPath)) {
-                    if (\unlink($metaPath)) {
-                        $output->writeln('<info>Deprecated file <comment>.phpstorm.meta.php</comment> removed</info>');
-                    }
-                }
-                if (!is_dir($metaPath)) {
-                    if (\mkdir($metaPath)) {
-                        $output->writeln('<info>Directory <comment>.phpstorm.meta.php</comment> created</info>');
-                    }
-                }
                 $group = str_replace(array(' ', '/'), '_', $group);
                 if (\file_put_contents($this->_magentoRootFolder . '/.phpstorm.meta.php/magento_' . $group . '_methods.meta.php', $map)) {
                     $output->writeln('<info>File <comment>.phpstorm.meta.php/magento_' . $group . '_methods.meta.php</comment> generated</info>');


### PR DESCRIPTION
Phpstorm can't resolve methods if helpers are called via helper method:

```
    protected function helper($name)
    {
        return Mage::helper($name);
    }
```

```
    $this->helper('payment')->getBillingAgreementMethods()
```

This PR takes the already collected helper classes and outputs them in a new file to make them "readable" ...

```
namespace PHPSTORM_META {
    override( \Mage_Admin_Model_User::_getHelper(0),
        map( [
            'adminnotification/data' => \Mage_AdminNotification_Helper_Data::class,
           ...
```

Note: does not support old output format.

**Update:**

Detect created blocks

```
    $select = $this->getLayout()->createBlock('core/html_select')
````