### PR TITLE
fix db dump error status

### DIFF
--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -262,7 +262,9 @@ HELP;
 
         list($fileName, $execs) = $this->createExecsArray($input, $output);
 
-        $this->runExecs($execs, $fileName, $input, $output);
+        $success = $this->runExecs($execs, $fileName, $input, $output);
+
+        return $success ? 0 : 1; // return with correct exec code
     }
 
     /**
@@ -343,6 +345,7 @@ HELP;
      * @param string $fileName
      * @param InputInterface $input
      * @param OutputInterface $output
+     * @return bool
      */
     private function runExecs(array $execs, $fileName, InputInterface $input, OutputInterface $output)
     {
@@ -362,7 +365,7 @@ HELP;
 
             foreach ($commands as $command) {
                 if (!$this->runExec($command, $input, $output)) {
-                    return;
+                    return false;
                 }
             }
 
@@ -374,6 +377,8 @@ HELP;
         if ($input->getOption('print-only-filename')) {
             $output->writeln($fileName);
         }
+
+        return true;
     }
 
     /**
@@ -387,14 +392,14 @@ HELP;
         $commandOutput = '';
 
         if ($input->getOption('stdout')) {
-            passthru($command, $returnValue);
+            passthru($command, $returnCode);
         } else {
-            Exec::run($command, $commandOutput, $returnValue);
+            Exec::run($command, $commandOutput, $returnCode);
         }
 
-        if ($returnValue > 0) {
+        if ($returnCode > 0) {
             $output->writeln('<error>' . $commandOutput . '</error>');
-            $output->writeln('<error>Return Code: ' . $returnValue . '. ABORTED.</error>');
+            $output->writeln('<error>Return Code: ' . $returnCode . '. ABORTED.</error>');
 
             return false;
         }

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -22,6 +22,11 @@ class Exec
     const CODE_CLEAN_EXIT = 0;
 
     /**
+     * Every error in a pipe will be exited with an error code
+     */
+    const SET_O_PIPEFAIL = 'set -o pipefail; ';
+
+    /**
      * @param string $command
      * @param string|null $output
      * @param int $returnCode
@@ -33,7 +38,7 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        $command = $command . self::REDIRECT_STDERR_TO_STDOUT;
+        $command = self::SET_O_PIPEFAIL . $command . self::REDIRECT_STDERR_TO_STDOUT;
 
         exec($command, $outputArray, $returnCode);
         $output = self::parseCommandOutput((array) $outputArray);

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -38,7 +38,11 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        $command = self::SET_O_PIPEFAIL . $command . self::REDIRECT_STDERR_TO_STDOUT;
+        if (OperatingSystem::isBashCompatibleShell()) {
+            $command = self::SET_O_PIPEFAIL . $command;
+        }
+
+        $command .= self::REDIRECT_STDERR_TO_STDOUT;
 
         exec($command, $outputArray, $returnCode);
         $output = self::parseCommandOutput((array) $outputArray);

--- a/src/N98/Util/Exec.php
+++ b/src/N98/Util/Exec.php
@@ -24,7 +24,7 @@ class Exec
     /**
      * Every error in a pipe will be exited with an error code
      */
-    const SET_O_PIPEFAIL = 'set -o pipefail; ';
+    const SET_O_PIPEFAIL = 'set -o pipefail;';
 
     /**
      * @param string $command
@@ -38,7 +38,7 @@ class Exec
             throw new RuntimeException($message);
         }
 
-        if (OperatingSystem::isBashCompatibleShell()) {
+        if (OperatingSystem::isBashCompatibleShell() && self::isPipefailOptionAvailable()) {
             $command = self::SET_O_PIPEFAIL . $command;
         }
 
@@ -73,5 +73,15 @@ class Exec
     private static function parseCommandOutput(array $commandOutput)
     {
         return implode(PHP_EOL, $commandOutput) . PHP_EOL;
+    }
+
+    /**
+     * @return bool
+     */
+    private static function isPipefailOptionAvailable()
+    {
+        exec('set -o | grep pipefail 2>&1', $output, $returnCode);
+
+        return $returnCode == self::CODE_CLEAN_EXIT;
     }
 }

--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -134,4 +134,15 @@ class OperatingSystem
 
         return '/usr/bin/env php';
     }
+
+    /**
+     * @return bool
+     */
+    public static function isBashCompatibleShell()
+    {
+        return in_array(
+            basename(getenv('SHELL')),
+            ['bash', 'zsh']
+        );
+    }
 }


### PR DESCRIPTION
Pipe commands are not handled correct.
The db:dump command will always return "0" which means "correct" even if an error occurs.
