### PR TITLE
Remove not needed "continue" to be compatible with PHP 7.3

### DIFF
--- a/src/N98/Magento/Command/ScriptCommand.php
+++ b/src/N98/Magento/Command/ScriptCommand.php
@@ -127,13 +127,13 @@ HELP;
             if (empty($commandString)) {
                 continue;
             }
+
             $firstChar = substr($commandString, 0, 1);
 
             switch ($firstChar) {
 
                 // comment
                 case '#':
-                    continue;
                     break;
 
                 // set var


### PR DESCRIPTION
This is a fix for issue #1014