### PR TITLE
Change config init to Magento's reinit function

### DIFF
--- a/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
+++ b/src/N98/Magento/Command/Cache/AbstractCacheCommand.php
@@ -83,8 +83,7 @@ class AbstractCacheCommand extends AbstractMagentoCommand
         }
 
         \Mage::getConfig()->getOptions()->setData('global_ban_use_cache', false);
-        \Mage::app()->baseInit(array()); // Re-init cache
-        \Mage::getConfig()->loadModules()->loadDb()->saveCache();
+        \Mage::getConfig()->reinit();
     }
 
     /**


### PR DESCRIPTION
Applies the change suggested in the comments of issue https://github.com/netz98/n98-magerun/issues/583

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject:

Fixes #583 

Changes proposed in this pull request:

- Changes the config init logic to Magento's own reinit function in the Config model to prevent issues with the `CONFIG` cache tag being cleared without being rebuilt when using the Redis cache storage engine.