### PR TITLE
Fix invalid composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
     "require-dev": {
         "bamarni/symfony-console-autocomplete": "^1.2.0",
         "friendsofphp/php-cs-fixer": "~1.12.0",
-        "mikey179/vfsStream": "~1.4",
         "phing/phing": "~2.10.0",
         "phpunit/phpunit": "~4.1",
-        "seld/phar-utils": "1.0.1"
+        "seld/phar-utils": "1.0.1",
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ed3c51d9570bc29e3f735170f7fac56",
+    "content-hash": "7324f7cd8106757de0613f4daacc8e46",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -1776,24 +1776,24 @@
             "time": "2016-11-15T09:10:47+00:00"
         },
         {
-            "name": "mikey179/vfsStream",
-            "version": "v1.6.6",
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d"
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
-                "reference": "095238a0711c974ae5b4ebf4c4534a23f3f6c99d",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5"
+                "phpunit/phpunit": "^4.5|^5.0"
             },
             "type": "library",
             "extra": {
@@ -1819,7 +1819,7 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2019-04-08T13:54:32+00:00"
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "phing/phing",


### PR DESCRIPTION
Compsoer 2.0 will not allow package names with uppercase letters.

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

Fixes: Invalid composer.json