### PR TITLE
Fix instances of PHP Fatal error:  Uncaught ArgumentCountError

### DIFF
--- a/src/N98/Magento/Command/Indexer/AbstractMviewIndexerCommand.php
+++ b/src/N98/Magento/Command/Indexer/AbstractMviewIndexerCommand.php
@@ -11,7 +11,7 @@ class AbstractMviewIndexerCommand extends AbstractMagentoCommand
      */
     public function getMetaDataCollection()
     {
-        $collection = $this->_getModel('enterprise_mview/metadata')->getCollection();
+        $collection = $this->_getModel('enterprise_mview/metadata', '\Enterprise_Mview_Model_Resource_Metadata_Collection')->getCollection();
         return $collection;
     }
 
@@ -21,7 +21,7 @@ class AbstractMviewIndexerCommand extends AbstractMagentoCommand
     protected function getIndexers()
     {
         /** @var \Enterprise_Index_Helper_Data $helper */
-        $helper = $this->_getHelper('enterprise_index');
+        $helper = $this->_getHelper('enterprise_index', '\Enterprise_Index_Helper_Data');
 
         $indexers = array();
         foreach ($helper->getIndexers(true) as $indexer) {
@@ -42,6 +42,6 @@ class AbstractMviewIndexerCommand extends AbstractMagentoCommand
      */
     protected function getMviewClient()
     {
-        return $this->_getModel('enterprise_mview/client');
+        return $this->_getModel('enterprise_mview/client', '\Enterprise_Mview_Model_Client');
     }
 }

--- a/src/N98/Magento/Command/Indexer/ListMviewCommand.php
+++ b/src/N98/Magento/Command/Indexer/ListMviewCommand.php
@@ -87,7 +87,7 @@ HELP;
     protected function getPendingChangelogsCount($tableName, $currentVersionId)
     {
         /** @var \Mage_Core_Model_Resource $resource */
-        $resource = $this->_getSingleton('core/resource');
+        $resource = $this->_getSingleton('core/resource', '\Mage_Core_Model_Resource');
         $readConnection = $resource->getConnection('core_read');
 
         $select = $readConnection->select()


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function N98\Magento\Command\AbstractMagentoCommand::_getModel()
```

When I built these commands in https://github.com/netz98/n98-magerun/pull/891 I erroneously neglected to pass the 2nd argument to `_getModel` and `_getSingleton`

I was using this today on a client running PHP 7 and this is now a proper error, previously I imagine a warning or notice slipped by on PHP 5.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
