### PR TITLE
Possible fix for #1046

### DIFF
--- a/src/N98/Magento/Command/Cache/CleanCommand.php
+++ b/src/N98/Magento/Command/Cache/CleanCommand.php
@@ -63,11 +63,16 @@ HELP;
         }
 
         $this->detectMagento($output, true);
-        if (!$this->initMagento()) {
+        if (!$this->initMagento(true)) {
             return;
         }
 
-        \Mage::app()->loadAreaPart('adminhtml', 'events');
+        try {
+            \Mage::app()->loadAreaPart('adminhtml', 'events');
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+        }
+
         $allTypes = \Mage::app()->getCacheInstance()->getTypes();
         $typesToClean = $input->getArgument('type');
         $this->validateCacheCodes($typesToClean);

--- a/src/N98/Magento/Command/Cache/FlushCommand.php
+++ b/src/N98/Magento/Command/Cache/FlushCommand.php
@@ -58,7 +58,12 @@ HELP;
             return;
         }
 
-        \Mage::app()->loadAreaPart('adminhtml', 'events');
+        try {
+            \Mage::app()->loadAreaPart('adminhtml', 'events');
+        } catch (\Exception $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+        }
+
         \Mage::dispatchEvent('adminhtml_cache_flush_all', array('output' => $output));
         $result = \Mage::app()->getCacheInstance()->flush();
         if ($result) {


### PR DESCRIPTION
DB init is triggered by Mage::app().
We catch the exception of the wrong cached db credentials an continue.

Fixes #1046

Changes proposed in this pull request:

- Catch exception do not stop command execution if wrong DB credentials are stored.