### PR TITLE
Remove mcrypt from required PHP extensions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -746,7 +746,6 @@ commands:
     php:
       required-extensions:
         - simplexml
-        - mcrypt
         - hash
         - gd
         - dom


### PR DESCRIPTION
Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)
- [X] README.md reflects changes (if any)

Changes proposed in this pull request:

- Remove `mcrypt` from list of required PHP extensions.
