### PR TITLE
Update for new standard phpstorm.meta used by the JetBrains/phpstorm-stubs library

### DIFF
--- a/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
@@ -23,35 +23,19 @@ class MetaCommandTest extends TestCase
 
         $fileContent = $commandTester->getDisplay(true);
 
-<<<<<<< HEAD
         $this->assertContains('\'catalog\' => \Mage_Catalog_Helper_Data', $fileContent);
         $this->assertContains('\'core/config\' => \Mage_Core_Model_Config', $fileContent);
-=======
-        $this->assertContains('\'catalog\' instanceof \Mage_Catalog_Helper_Data', $fileContent);
-        $this->assertContains('\'core/config\' instanceof \Mage_Core_Model_Config', $fileContent);
-
->>>>>>> 5b96ffd464983ace8f5e352db4701f0f3e9f7be5
         if (class_exists('\Mage_Core_Model_Resource_Config')) { // since magento 1.7
             $this->assertContains('\'core/config\' => \Mage_Core_Model_Resource_Config', $fileContent);
         }
-<<<<<<< HEAD
         $this->assertContains('\'wishlist\' => \Mage_Wishlist_Helper_Data', $fileContent);
-=======
-
-        $this->assertContains('\'wishlist\' instanceof \Mage_Wishlist_Helper_Data', $fileContent);
-
->>>>>>> 5b96ffd464983ace8f5e352db4701f0f3e9f7be5
         if (class_exists('\Mage_Core_Model_Resource_Helper_Mysql4')) {
             $this->assertContains('\'core\' => \Mage_Core_Model_Resource_Helper_Mysql4', $fileContent);
         }
-<<<<<<< HEAD
         $this->assertNotContains(
             '\'core/mysql4_design_theme_collection\' => \Mage_Core_Model_Mysql4_Design_Theme_Collection',
             $fileContent
         );
-=======
-
->>>>>>> 5b96ffd464983ace8f5e352db4701f0f3e9f7be5
         $this->assertNotContains(
             '\'payment/paygate_request\' => \Mage_Payment_Model_Paygate_Request',
             $fileContent

--- a/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
@@ -25,17 +25,17 @@ class MetaCommandTest extends TestCase
 
         $this->assertContains('\'catalog\' => \Mage_Catalog_Helper_Data', $fileContent);
         $this->assertContains('\'core/config\' => \Mage_Core_Model_Config', $fileContent);
+
         if (class_exists('\Mage_Core_Model_Resource_Config')) { // since magento 1.7
             $this->assertContains('\'core/config\' => \Mage_Core_Model_Resource_Config', $fileContent);
         }
+
         $this->assertContains('\'wishlist\' => \Mage_Wishlist_Helper_Data', $fileContent);
+
         if (class_exists('\Mage_Core_Model_Resource_Helper_Mysql4')) {
             $this->assertContains('\'core\' => \Mage_Core_Model_Resource_Helper_Mysql4', $fileContent);
         }
-        $this->assertNotContains(
-            '\'core/mysql4_design_theme_collection\' => \Mage_Core_Model_Mysql4_Design_Theme_Collection',
-            $fileContent
-        );
+
         $this->assertNotContains(
             '\'payment/paygate_request\' => \Mage_Payment_Model_Paygate_Request',
             $fileContent

--- a/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
+++ b/tests/N98/Magento/Command/Developer/Ide/PhpStorm/MetaCommandTest.php
@@ -23,21 +23,21 @@ class MetaCommandTest extends TestCase
 
         $fileContent = $commandTester->getDisplay(true);
 
-        $this->assertContains('\'catalog\' instanceof \Mage_Catalog_Helper_Data', $fileContent);
-        $this->assertContains('\'core/config\' instanceof \Mage_Core_Model_Config', $fileContent);
+        $this->assertContains('\'catalog\' => \Mage_Catalog_Helper_Data', $fileContent);
+        $this->assertContains('\'core/config\' => \Mage_Core_Model_Config', $fileContent);
         if (class_exists('\Mage_Core_Model_Resource_Config')) { // since magento 1.7
-            $this->assertContains('\'core/config\' instanceof \Mage_Core_Model_Resource_Config', $fileContent);
+            $this->assertContains('\'core/config\' => \Mage_Core_Model_Resource_Config', $fileContent);
         }
-        $this->assertContains('\'wishlist\' instanceof \Mage_Wishlist_Helper_Data', $fileContent);
+        $this->assertContains('\'wishlist\' => \Mage_Wishlist_Helper_Data', $fileContent);
         if (class_exists('\Mage_Core_Model_Resource_Helper_Mysql4')) {
-            $this->assertContains('\'core\' instanceof \Mage_Core_Model_Resource_Helper_Mysql4', $fileContent);
+            $this->assertContains('\'core\' => \Mage_Core_Model_Resource_Helper_Mysql4', $fileContent);
         }
         $this->assertNotContains(
-            '\'core/mysql4_design_theme_collection\' instanceof \Mage_Core_Model_Mysql4_Design_Theme_Collection',
+            '\'core/mysql4_design_theme_collection\' => \Mage_Core_Model_Mysql4_Design_Theme_Collection',
             $fileContent
         );
         $this->assertNotContains(
-            '\'payment/paygate_request\' instanceof \Mage_Payment_Model_Paygate_Request',
+            '\'payment/paygate_request\' => \Mage_Payment_Model_Paygate_Request',
             $fileContent
         );
     }


### PR DESCRIPTION
Update for new standard phpstorm.meta used by the JetBrains/phpstorm-stubs library:
https://github.com/JetBrains/phpstorm-stubs

I replaced the "$STATIC_METHOD_TYPES[]" wrapper with the "override()" method.

#### Fixes:
https://github.com/netz98/n98-magerun/issues/1140
