### PR TITLE
Run Test Setup in Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,7 @@ jobs:
         with:
           php-version: '7.3'
 
-      - id: composer-cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.cache/composer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
       - {name: mysqld,shell: bash,run: 'sudo systemctl start mysql.service'}
       - uses: ktomk/run-travis-yml@v1
         with:
-          run_job: ${{ matrix.run-job }}
+          run-job: ${{ matrix.run-job }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     name: ${{ matrix.run-job }}
     runs-on: ${{ matrix.machine }}
     continue-on-error: ${{ matrix.experimental }}
-    needs: build
+    needs: [build, test-setup]
 
     strategy:
       fail-fast: false
@@ -75,3 +75,30 @@ jobs:
       - uses: ktomk/run-travis-yml@v1
         with:
           run-job: ${{ matrix.run-job }}
+
+
+  test-setup:
+    name: Test Setup
+    runs-on: ubuntu-18.04
+    steps:
+      - {name: mysqld,shell: bash,run: 'sudo systemctl start mysql.service'}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/composer
+            vendor
+          key: composer-${{ hashFiles('composer.lock') }}-test-setup-${{ runner.os }}-
+          restore-keys: |
+            composer-${{ hashFiles('composer.lock') }}-test-setup-${{ runner.os }}-
+            composer-${{ hashFiles('composer.lock') }}-test-setup-
+            composer-${{ hashFiles('composer.lock') }}-
+            composer-
+
+      - name: test_setup.sh
+        shell: bash
+        run: |
+          composer install --ignore-platform-reqs --prefer-dist --no-progress --no-suggest
+          test_setup_db_pass=root \
+          test_setup_magento_version=openmage-20.0.4 \
+              build/local/test_setup.sh

--- a/build/local/test_setup.sh
+++ b/build/local/test_setup.sh
@@ -22,21 +22,22 @@ magento_is_installed() {
     fi
 }
 
-test_setup_basename="n98-magerun"
-test_setup_magerun_cmd="bin/${test_setup_basename}"
-test_setup_directory="./magento/www"
-test_setup_db_host="127.0.0.1"
+test_setup_basename="${test_setup_basename-n98-magerun}"
+test_setup_magerun_cmd="${test_setup_magerun_cmd-bin/$test_setup_basename}"
+test_setup_directory="${test_setup_directory-./magento/www}"
+test_setup_db_host="${test_setup_db_host-127.0.0.1}"
 test_setup_db_port="${test_setup_db_port:-3306}"
-test_setup_db_user="root"
-test_setup_db_pass=""
-test_setup_db_name="magento_magerun_test"
+test_setup_db_user="${test_setup_db_user-root}"
+test_setup_db_pass="${test_setup_db_pass-}"
+test_setup_db_name="${test_setup_db_name-magento_magerun_test}"
+test_setup_magento_version="${test_setup_magento_version-magento-mirror-1.9.4.5}"
 
 if [ "" != "$(installed_version)" ]; then
     buildecho "version '$(installed_version)' already installed, skipping setup"
 else
     ensure_environment
     ensure_mysql_db
-    ensure_magento "magento-mirror-1.9.2.3"
+    ensure_magento "$test_setup_magento_version"
 fi
 
 # create stopfile if it does not yet exists


### PR DESCRIPTION
After starting the migration from Travis-CI to Github CI in 3ca8553 the
build scripts in general came to attention for review.

Most prominently likely is

    build/local/test_setup.sh

which is the standard setup test/build: Install a Magento version with
Magerun.

Despite being important in (local!) CI, it has not yet been put into the
projects CI so far (at least not in the form of the build script).

Add the Test Setup to the CI running w/ Github Actions.

This change-set contains required changes to the build script itself so
that the db password and the Magento version can be injected. Change here
is to allow any of the test_setup_* parameters to be overridden which
previously was not possible.

Rationale on these changes:

The Ubuntu-18.04 runner on Github Actions currently runs PHP 8.0:

- As the default version in the build script is "magento-mirror-1.9.2.3"
  the different, PHP 8 compatible "openmage-20.0.4" version is in use.

- Magerun itself is not strictly install-able on PHP 8.0, composer install
  requires the --ignore-platform-reqs flag for the source version.

NOTE: The default test-runner version has been changed to the current
latest magento-mirror-1.9.4.5 version (taken from .travis.yml, change is
from magento-mirror-1.9.2.3). Both are _not_ compatible with the PHP 8.0
version on the Github runner:

> Fatal error: Uncaught Error: Call to undefined function
> get_magic_quotes_gpc() in ...
> /magento/www/app/code/core/Mage/Core/functions.php` on line 32

- Ref: 3ca8553259fc4b3ec6d6c8f16cbb61bede9b84c5
- Ref-Issue: #1138
- By-Catch-Issue: #1133 (runs `magerun install` command with recent Openmage Magento under PHP 8.0)

---

Magerun pull-request check-list:

- [X] Pull request against develop branch (if not, just close and create a new one against it)

