### PR TITLE
Fix "$default-branch" macro use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: CI
 on:
   push:
     branches:
-      - $default-branch
+      - 'master'
       - 'develop'
       - 'bugfix/*'
       - 'feature/*'
       - 'release/*'
   pull_request:
     branches:
-      - $default-branch
+      - 'master'
       - 'develop'
 
 jobs:


### PR DESCRIPTION
Missing the "master" build on Github Actions.

The macro is for a workflow template only.

Fix is to use verbatim "master" again.

Related-Issue: #1138

---

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)
