### PR TITLE
Change autoloading from PSR-0 to PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,13 @@
         "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
-        "psr-0": {
-            "N98": "src"
-        },
         "psr-4": {
+            "N98\\": "src/N98"
         }
     },
     "autoload-dev": {
-        "psr-0": {
-            "N98": "tests"
+        "psr-4": {
+            "N98\\": "tests/N98"
         }
     },
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -529,25 +529,25 @@
         },
         {
             "name": "n98/junit-xml",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cmuench/junit-xml.git",
-                "reference": "7df0dbaf413fcaa1a63ffbcef18654e7a4cceb46"
+                "reference": "0017dd92ac8cb619f02e32f4cffd768cfe327c73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cmuench/junit-xml/zipball/7df0dbaf413fcaa1a63ffbcef18654e7a4cceb46",
-                "reference": "7df0dbaf413fcaa1a63ffbcef18654e7a4cceb46",
+                "url": "https://api.github.com/repos/cmuench/junit-xml/zipball/0017dd92ac8cb619f02e32f4cffd768cfe327c73",
+                "reference": "0017dd92ac8cb619f02e32f4cffd768cfe327c73",
                 "shasum": ""
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*"
+                "phpunit/phpunit": "^9.5.0"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "N98\\JUnitXml": "src/"
+                "psr-4": {
+                    "N98\\JUnitXml\\": "src/N98/JUnitXml"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -561,7 +561,11 @@
                 }
             ],
             "description": "JUnit XML Document generation library",
-            "time": "2013-11-23T13:11:26+00:00"
+            "support": {
+                "issues": "https://github.com/cmuench/junit-xml/issues",
+                "source": "https://github.com/cmuench/junit-xml/tree/1.1.0"
+            },
+            "time": "2020-12-25T09:08:58+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/tests/N98/Magento/ApplicationTest.php
+++ b/tests/N98/Magento/ApplicationTest.php
@@ -32,8 +32,8 @@ class ApplicationTest extends TestCase
         $this->assertEquals(Application::APP_VERSION, trim(file_get_contents(__DIR__ . '/../../../version.txt')));
 
         /* @var $loader \Composer\Autoload\ClassLoader */
-        $prefixes = $loader->getPrefixes();
-        $this->assertArrayHasKey('N98', $prefixes);
+        $prefixes = $loader->getPrefixesPsr4();
+        $this->assertArrayHasKey('N98\\', $prefixes);
 
         $distConfigArray = Yaml::parse(file_get_contents(__DIR__ . '/../../../config.yaml'));
 

--- a/tests/N98/Magento/TestApplication.php
+++ b/tests/N98/Magento/TestApplication.php
@@ -63,7 +63,7 @@ class TestApplication
         # directory test
         if (!is_dir($root)) {
             throw new RuntimeException(
-                sprintf("%s path '%s' is not a directory", $varname, $root)
+                sprintf("%s path '%s' is not a directory (cwd: '%s', stopfile: '%s')", $varname, $root, getcwd(), $stopfile)
             );
         }
 


### PR DESCRIPTION
Previously while unsharing the shared folder in #1149 it came to attention 
that the autoloading in projects composer.json was still configured as
PSR-0 which is deprecated since longer.

Change is to switch to PSR-4 autoloading.

- [x] update for n98/junit-xml 1.1.0 (affects internal test)
- [x] check if the PSR-4 works also in combination with n98-magerun modules

---

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)