### PR TITLE
Feature/dev maintenance

### DIFF
--- a/src/N98/Magento/Application/ConfigFile.php
+++ b/src/N98/Magento/Application/ConfigFile.php
@@ -109,4 +109,12 @@ class ConfigFile
 
         return ArrayFunctions::mergeArrays($array, $result);
     }
+
+    /**
+     * @return string path to config-file
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
 }

--- a/src/N98/Magento/Application/ConfigurationLoader.php
+++ b/src/N98/Magento/Application/ConfigurationLoader.php
@@ -273,6 +273,7 @@ class ConfigurationLoader
             $this->_userConfig = array();
             $locator = new ConfigLocator($this->_customConfigFilename, $magentoRootFolder);
             if ($userConfigFile = $locator->getUserConfigFile()) {
+                $this->logDebug('Load user config <comment>' . $userConfigFile->getPath() . '</comment>');
                 $this->_userConfig = $userConfigFile->toArray();
             }
         }

--- a/tests/N98/Magento/Application/ConfigTest.php
+++ b/tests/N98/Magento/Application/ConfigTest.php
@@ -144,6 +144,10 @@ class ConfigTest extends TestCase
             'autoloaders_psr4' => array('$prefix\\' => '$path'),
         );
 
+        $expected =
+            '<debug>Registered PSR-0 autoloader </debug> $prefix -> $path' . "\n" .
+            '<debug>Registered PSR-4 autoloader </debug> $prefix\\ -> $path' . "\n";
+
         $output = new BufferedOutput();
 
         $config = new Config(array(), false, $output);
@@ -154,6 +158,8 @@ class ConfigTest extends TestCase
 
         $output->setVerbosity($output::VERBOSITY_DEBUG);
         $config->registerCustomAutoloaders($autloader);
+
+        self::assertSame($expected, $output->fetch());
     }
 
     /**


### PR DESCRIPTION
The fix for -vvv display of the user-config file was missing in #1154

Improves the config-test to assert actual output (previously there were no assertions in the test-case).

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
