### PR TITLE
Use compressed sample-data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -603,37 +603,37 @@ commands:
       - name: sample-data-1.9.2.4
         version: 1.9.2.4
         dist:
-          url: https://sourceforge.net/projects/mageloads/files/assets/1.9.2.4/magento-sample-data-1.9.2.4-fix.tar.gz
-          type: tar
-          shasum: fe5930d0f41c2b5e92b86f7f7fc4247c927efa01
+          url: https://github.com/sreichel/magento-1-compressed-sample-data/raw/master/magento-sample-data-1.9.2.4.zip
+          type: zip
+          shasum: 243a47cf216c83074f8b657f42d6707940646823
 
       - name: sample-data-1.9.1.0
         version: 1.9.1.0
         dist:
-          url: https://sourceforge.net/projects/mageloads/files/assets/1.9.1.0/magento-sample-data-1.9.1.0.tar.gz
-          type: tar
-          shasum: 617e0271900772ac8f11e7bb86e29fca0f640562
+          url: https://github.com/sreichel/magento-1-compressed-sample-data/raw/master/magento-sample-data-1.9.1.0.zip
+          type: zip
+          shasum: 0d4145ae3fc732de24f2ae504c908991db3bc01c
 
       - name: sample-data-1.9.0.0
         version: 1.9.0.0
         dist:
-          url: https://sourceforge.net/projects/mageloads/files/assets/1.9.0.0/magento-sample-data-1.9.0.0.tar.gz
-          type: tar
-          shasum: b2b535901eb2db92a8602baf8a839ab2120c4c8f
+          url: https://github.com/sreichel/magento-1-compressed-sample-data/raw/master/magento-sample-data-1.9.0.0.zip
+          type: zip
+          shasum: 24c7144d106fb1165e3e730fd040780e23dd9c60
 
       - name: sample-data-1.6.1.0
         version: 1.6.1.0
         dist:
-          url: https://sourceforge.net/projects/mageloads/files/assets/1.6.1.0/magento-sample-data-1.6.1.0.tar.gz
-          type: tar
-          shasum: a9226bc92966855327f6eb62ff8f6c562b2113a2
+          url: https://github.com/sreichel/magento-1-compressed-sample-data/raw/master/magento-sample-data-1.6.1.0.zip
+          type: zip
+          shasum: 81b7b82d4223fdcd823ab62f7fac9c38efad47b8
 
       - name: sample-data-1.1.2
         version: 1.1.2
         dist:
-          url: https://sourceforge.net/projects/mageloads/files/assets/1.1.2/magento-sample-data-1.1.2.zip
+          url: https://github.com/sreichel/magento-1-compressed-sample-data/raw/master/magento-sample-data-1.1.2.zip
           type: zip
-          shasum: 6bbb57e387c59da2752fe013aadef6dcd3cd2b29
+          shasum: c816cb97ec089eed73101324a9b154a88e00b262
 
     installation:
       pre-check:


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Use 95MB compressed sample data instead of current 430MB.

I'v just compressed mp3 to 48k and reduced image quality to 50%.  It's not as optimized as https://github.com/Vinai/compressed-magento-sample-data yet, but that's coming. (Eventually.)

---

I tried `tar.xz` (~50MB) but install sample data fails with ...
```

  [UnexpectedValueException]                                                                                                                                    
  internal corruption of phar "/home/sr/workspace/tests/n98/magento/_temp_demo_data/3b521eeeb430578bc0efd3d2876d834a.xz" (__HALT_COMPILER(); not found)  
```
