### PR TITLE
Add OpenMage 20.0.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - machine: 'ubuntu-18.04'
             php-version: '7.3'
-            run-job: 'OpenMage LTS 20.0.6 PHP 7.3'
+            run-job: 'OpenMage LTS 20.0.10 PHP 7.3'
             experimental: false
 
     env:
@@ -101,7 +101,7 @@ jobs:
         run: |
           composer install --ignore-platform-reqs --prefer-dist --no-progress --no-suggest
           test_setup_db_pass=root \
-          test_setup_magento_version=openmage-20.0.6 \
+          test_setup_magento_version=openmage-20.0.10 \
               build/local/test_setup.sh
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ matrix:
       php: 7.2
       env: MAGENTO_VERSION="magento-mirror-1.9.4.5" DB=mysql INSTALL_SAMPLE_DATA=no
 
-    - name: OpenMage LTS 20.0.6 PHP 7.3
+    - name: OpenMage LTS 20.0.10 PHP 7.3
       php: 7.3
-      env: MAGENTO_VERSION="openmage-20.0.6" DB=mysql INSTALL_SAMPLE_DATA=no
+      env: MAGENTO_VERSION="openmage-20.0.10" DB=mysql INSTALL_SAMPLE_DATA=no
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,27 @@
 RECENT CHANGES
 ==============
 
-2.2.0-dev
----------
+2.2.0
+-----
+
+- Add: OpenMage 20.0.10 (by Christian Münch)
+- Add: maintenance badge (by Christian Münch)
+- Add: ext-simplexml for test-suite (by Tom Klingenberg)
+- Add: makefile (by Tom Klingenberg)
+- Add: missing changelog entry (by Christian Münch)
+- Imp: Change autoloading from psr-0 to psr-4 (by Tom Klingenberg)
+- Fix: Fix-up message improvements (by Tom Klingenberg)
+- Fix unnecessary assertions (by Tom Klingenberg)
+- Fix static method invocations via '->' (by Tom Klingenberg)
+- Fix missing assertion in config-test (by Tom Klingenberg)
+- Fix missing debug output for user-config-file (by Tom Klingenberg)
+- Fix namespace for composer init-command-test (by Tom Klingenberg)
+- Fix clover.xml path (by Tom Klingenberg)
+- Fix "$default-branch" macro use (by Tom Klingenberg)
+- Del: unused import statements (by Tom Klingenberg)
+- Del: superfluous @test annotations (by Tom Klingenberg)
+- Del: deprecated string class (by Tom Klingenberg)
+- Del: magerun magento2 entry-point (by Tom Klingenberg)
 
 2.1.0
 -----

--- a/config.yaml
+++ b/config.yaml
@@ -182,6 +182,14 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
+      - name: openmage-20.0.10
+        version: 20.0.10
+        dist:
+          url: https://github.com/OpenMage/magento-lts/archive/v20.0.10.zip
+          type: zip
+          shasum: 2702a588b6d8668707b1a785f9b634d1fdb4ec01
+        extra:
+          sample-data: sample-data-1.9.2.4
       - name: openmage-20.0.6
         version: 20.0.6
         dist:


### PR DESCRIPTION
- Add OpenMage 20.0.10 as new version to installer.
- Set OpenMage 20.0.10 as version in test setup