### PR TITLE
Bump bamarni/symfony-console-autocomplete from 1.5.4 to 1.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: PHP Composer
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3
@@ -61,12 +61,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        machine: ['ubuntu-18.04']
+        machine: ['ubuntu-20.04']
         php-version: ['7.2']
         run-job: ['SH lint', 'Buildsh', 'Bash Autocompletion', 'Magento 1.9.4.5 PHP 7.2']
         experimental: [false]
         include:
-          - machine: 'ubuntu-18.04'
+          - machine: 'ubuntu-20.04'
             php-version: '7.3'
             run-job: 'OpenMage LTS 20.0.14 PHP 7.3'
             experimental: false
@@ -99,7 +99,7 @@ jobs:
 
   test-setup:
     name: Test Setup
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - {name: mysqld,shell: bash,run: 'sudo systemctl start mysql.service'}
 
@@ -136,7 +136,7 @@ jobs:
 
   codecov: # previously codecov was bound via circleci which paused for ~two years
     name: Code Coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - {name: mysqld,shell: bash,run: 'sudo systemctl start mysql.service'}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - 'master'
       - 'develop'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -101,7 +102,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - {name: mysqld,shell: bash,run: 'sudo systemctl start mysql.service'}
-      
+
       - name: Checkout PR
         uses: actions/checkout@v3
         if: github.event_name == 'pull_request_target'

--- a/composer.lock
+++ b/composer.lock
@@ -2014,16 +2014,16 @@
     "packages-dev": [
         {
             "name": "bamarni/symfony-console-autocomplete",
-            "version": "v1.5.4",
+            "version": "v1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/symfony-console-autocomplete.git",
-                "reference": "5adeafbc238e896b780eb8353e82cf7d6539e781"
+                "reference": "0623ac892aeb2a81ffcdf0e963bcbc450d52638d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/symfony-console-autocomplete/zipball/5adeafbc238e896b780eb8353e82cf7d6539e781",
-                "reference": "5adeafbc238e896b780eb8353e82cf7d6539e781",
+                "url": "https://api.github.com/repos/bamarni/symfony-console-autocomplete/zipball/0623ac892aeb2a81ffcdf0e963bcbc450d52638d",
+                "reference": "0623ac892aeb2a81ffcdf0e963bcbc450d52638d",
                 "shasum": ""
             },
             "require": {
@@ -2063,9 +2063,9 @@
             "description": "Shell completion for Symfony Console based scripts",
             "support": {
                 "issues": "https://github.com/bamarni/symfony-console-autocomplete/issues",
-                "source": "https://github.com/bamarni/symfony-console-autocomplete/tree/v1.5.4"
+                "source": "https://github.com/bamarni/symfony-console-autocomplete/tree/v1.5.5"
             },
-            "time": "2022-04-11T12:08:44+00:00"
+            "time": "2022-12-21T16:40:50+00:00"
         },
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Hand-picked dependency bump as automated didn't succeed.

Additionally introduces manual trigger for CI workflow and upgrades deprecated `ubuntu-18.04` to  `ubuntu-20.04`.