### PR TITLE
Fixes the "always" cron expression check

### DIFF
--- a/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
+++ b/src/N98/Magento/Command/System/Cron/AbstractCronCommand.php
@@ -85,7 +85,7 @@ abstract class AbstractCronCommand extends AbstractMagentoCommand
      */
     private function parseCronExpression($expr)
     {
-        if ($expr === 'always') {
+        if ((string)$expr === 'always') {
             return array_fill(0, 5, '*');
         }
 


### PR DESCRIPTION
Magerun pull-request check-list:

- [ ] Pull request against develop branch (if not, just close and create a new one against it)
- [ ] README.md reflects changes (if any)

Fixes #1280 

The cron expression that is passed to parseCronExpression() is not a string but a Mage_Core_Model_Config_Element instance.
Of course comparing a string to an object with a strict check will always return false. This PR explicitly casts the value to `string`, which has the effect of invoking the object's `__toString` method.