### PR TITLE
Fixes `Call to undefined method renderException()`

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -629,7 +629,7 @@ class Application extends BaseApplication
             $this->init([], $input, $output);
         } catch (Exception $e) {
             $output = new ConsoleOutput();
-            $this->renderException($e, $output->getErrorOutput());
+            $this->renderThrowable($e, $output->getErrorOutput());
         }
 
         $return = parent::run($input, $output);


### PR DESCRIPTION
**v3-dev**

`Uncaught Error: Call to undefined method N98\Magento\Application::renderException() in /var/www/html/vendor/n98/magerun/src/N98/Magento/Application.php:632`

To reproduce remove `setName()` from a command.

Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Subject: (50 characters or less)

Fixes # .

Changes proposed in this pull request:

Fixes error message.