### PR TITLE
Change netz98 to valantic CEC

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -92,7 +92,7 @@ The command should execute successfully and show you the version number of N98-M
 
 .. code-block:: sh
 
-    n98-magerun version 1.97.0 by netz98 new media GmbH
+    n98-magerun version 2.3.0 by valantic CEC
 
 You now have successfully installed Magerun! You can tailor the installation further like installing it system-wide and
 enable autocomplete - read on for more information about these and other features.

--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -485,7 +485,7 @@ class Application extends BaseApplication
 
     public function getLongVersion()
     {
-        return parent::getLongVersion() . ' by <info>netz98 GmbH</info>';
+        return parent::getLongVersion() . ' by <info>valantic CEC</info>';
     }
 
     /**

--- a/tests/N98/Magento/Command/ListCommandTest.php
+++ b/tests/N98/Magento/Command/ListCommandTest.php
@@ -16,7 +16,7 @@ class ListCommandTest extends TestCase
         );
 
         self::assertStringContainsString(
-            sprintf('n98-magerun %s by netz98 GmbH', $this->getApplication()->getVersion()),
+            sprintf('n98-magerun %s by valantic CEC', $this->getApplication()->getVersion()),
             $commandTester->getDisplay()
         );
     }


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (if any)

Summary:  The company netz98 is part of the valantic Group since 2019. Some days ago the legal entity netz98 GmbH was merged into the valantic Deutschland GmbH.
So we change the license info to reflect this legal changes.