### PR TITLE
Added OpenMage 20.10.2 release

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -159,6 +159,11 @@ commands:
 
   N98\Magento\Command\Installer\InstallCommand:
     magento-packages:
+      - name: openmage-20.10.2
+        package: openmage/magento-lts
+        version: 20.10.2
+        extra:
+          sample-data: sample-data-1.9.2.4
       - name: openmage-20.10.0
         package: openmage/magento-lts
         version: 20.10.0


### PR DESCRIPTION
- see https://github.com/OpenMage/magento-lts/discussions/4114

(skipped v20.10.1)