### PR TITLE
Require app/bootstrap.php during initialization

### DIFF
--- a/src/N98/Magento/Initializer.php
+++ b/src/N98/Magento/Initializer.php
@@ -17,6 +17,11 @@ use RuntimeException;
 class Initializer
 {
     /**
+     * Bootstrap filename
+     */
+    public const PATH_APP_BOOTSTRAP_PHP = 'app/bootstrap.php';
+
+    /**
      * Mage filename
      */
     public const PATH_APP_MAGE_PHP = 'app/Mage.php';
@@ -74,6 +79,9 @@ class Initializer
     {
         // Create a new AutoloadRestorer to capture current auto-loaders
         $autoloadRestorer = new AutoloadRestorer();
+
+        $path = $this->magentoPath . '/' . self::PATH_APP_BOOTSTRAP_PHP;
+        initialiser_require_once($path);
 
         $path = $this->magentoPath . '/' . self::PATH_APP_MAGE_PHP;
         initialiser_require_once($path);


### PR DESCRIPTION
Magerun pull-request check-list:

- [x] Pull request against develop branch (if not, just close and create a new one against it)
- [x] README.md reflects changes (N/A)

Subject: Require app/bootstrap.php during initialization


Changes proposed in this pull request:

For a while now, one is supposed to load both bootstrap.php and Mage.php when initializing M1, but n98 only included the latter. Including both will allow the eventual porting of back of Maho's autoloaders to OM.

Ping @sreichel please let me know what you think.