### PR TITLE
fix: suppress checkVarDir warning when /tmp/magento/var does not exist

### DIFF
--- a/src/N98/Magento/Application.php
+++ b/src/N98/Magento/Application.php
@@ -319,7 +319,7 @@ class Application extends BaseApplication
     public function checkVarDir(OutputInterface $output): ?bool
     {
         $tempVarDir = sys_get_temp_dir() . '/magento/var';
-        if (OutputInterface::VERBOSITY_NORMAL > $output->getVerbosity() && !is_dir($tempVarDir)) {
+        if (!is_dir($tempVarDir)) {
             return null;
         }
 


### PR DESCRIPTION
## Problem

`checkVarDir()` fires a spurious _"Folder /tmp/magento/var found, but not used"_ warning on every invocation, even when `/tmp/magento/var` doesn't exist on disk.

The root cause is the guard condition:

```php
if (OutputInterface::VERBOSITY_NORMAL > $output->getVerbosity() && !is_dir($tempVarDir)) {
    return null;
}
```

`VERBOSITY_NORMAL > $output->getVerbosity()` evaluates to `32 > 32` = `false` in normal verbosity mode, so the early return never fires regardless of whether the directory exists. The check then proceeds unconditionally and, since the configured var dir (`/var/www/htdocs/var`) never equals `/tmp/magento/var`, always falls into the `else` branch and prints the warning.

## Fix

Drop the verbosity condition. The check should only run — and warn — when `/tmp/magento/var` actually exists:

```php
if (!is_dir($tempVarDir)) {
    return null;
}
```

This preserves the existing behaviour for the case where the temp dir genuinely exists (both the "fallback used" and "found but not used" paths), while eliminating the false positive when it doesn't.