### PR TITLE
Fix strict_types errors in DumpCommand and extension autoloader registration

### DIFF
--- a/src/N98/Magento/Application/Config.php
+++ b/src/N98/Magento/Application/Config.php
@@ -185,6 +185,12 @@ class Config
     {
         $mask = '<debug>Registered %s autoloader </debug> <info>%s</info> -> <comment>%s</comment>';
 
+        if (($this->getArray('autoloaders') || $this->getArray('autoloaders_psr4'))
+            && $classLoader->isClassMapAuthoritative()
+        ) {
+            $classLoader->setClassMapAuthoritative(false);
+        }
+
         foreach ($this->getArray('autoloaders') as $prefix => $paths) {
             $this->debugWriteln(sprintf($mask, self::PSR_0, OutputFormatter::escape($prefix), implode(',', (array) $paths)));
             $classLoader->add($prefix, $paths);

--- a/src/N98/Magento/Command/Database/DumpCommand.php
+++ b/src/N98/Magento/Command/Database/DumpCommand.php
@@ -24,10 +24,6 @@ use Symfony\Component\Console\Question\Question;
  */
 class DumpCommand extends AbstractDatabaseCommand
 {
-    protected ?array $tableDefinitions;
-
-    protected array $commandConfig;
-
     protected function configure(): void
     {
         $this
@@ -167,27 +163,11 @@ HELP;
     }
 
     /**
-     * @deprecated Use database helper
-     */
-    private function getTableDefinitions(): array
-    {
-        $this->commandConfig = $this->getCommandConfig();
-
-        if (is_null($this->tableDefinitions)) {
-            $dbHelper = $this->getDatabaseHelper();
-            $this->tableDefinitions = $dbHelper->getTableDefinitions($this->commandConfig);
-        }
-
-        return $this->tableDefinitions;
-    }
-
-    /**
      * Generate help for table definitions
      */
     public function getTableDefinitionHelp(): string
     {
         $messages = PHP_EOL;
-        $this->commandConfig = $this->getCommandConfig();
         $messages .= <<<HELP
 <comment>Strip option</comment>
  If you like to skip data of some tables you can use the --strip option.
@@ -196,7 +176,7 @@ HELP;
 
  Separate each table to strip by a space.
  You can use wildcards like * and ? in the table names to strip multiple
- tables. In addition you can specify pre-defined table groups, that start
+ tables. In addition, you can specify pre-defined table groups, that start
  with an
 
  Example: "dataflow_batch_export unimportant_module_* @log
@@ -207,7 +187,7 @@ HELP;
 
 HELP;
 
-        $definitions = $this->getTableDefinitions();
+        $definitions = $this->getDatabaseHelper()->getTableDefinitions($this->getCommandConfig());
         $list = [];
         $maxNameLen = 0;
         foreach ($definitions as $id => $definition) {


### PR DESCRIPTION
This PR fixes two issues I ran into after building from develop:

  - Fix extension autoloader registration: Extensions declaring autoloaders or autoloaders_psr4 in their
  n98-magerun.yaml were silently ignored because the Composer classloader was running in authoritative classmap
  mode, which bypasses PSR-0/PSR-4 lookups entirely. The classloader now disables authoritative mode when an
  extension needs to register custom autoloaders.

  - Fix DumpCommand strict_types error: The $tableDefinitions property was uninitialized and guarded by an
  is_null check that fails under strict_types. Removed the unnecessary memoization ($tableDefinitions,
  $commandConfig) and the deprecated getTableDefinitions() method, inlining the single call directly via the
  database helper.
